### PR TITLE
Decouple cpp interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,33 +1,41 @@
 cmake_minimum_required(VERSION 3.18)
-project(_roshambo2 LANGUAGES CXX CUDA)
+option(BUILD_WITH_CUDA "Build the CUDA functionaility" ON)
 
+if (BUILD_WITH_CUDA)
+    project(_roshambo2 LANGUAGES CXX CUDA)
+else (BUILD_WITH_CUDA)
+    project(_roshambo2 LANGUAGES CXX)
+endif (BUILD_WITH_CUDA)
 # Find OpenMP package
 find_package(OpenMP REQUIRED)
 
 # Find CUDA
-find_package(CUDA REQUIRED)
+if (BUILD_WITH_CUDA)
+    find_package(CUDA REQUIRED)
+endif (BUILD_WITH_CUDA)
 
 # Find pybind
 find_package(pybind11)
 
-include_directories("${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}")
-
-# change here for newer or older cards
-set(CMAKE_CUDA_ARCHITECTURES 60 70 80)
-
+if (BUILD_WITH_CUDA)
+    include_directories("${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}")
+    # change here for newer or older cards
+    set(CMAKE_CUDA_ARCHITECTURES 60 70 80)
+endif (BUILD_WITH_CUDA)
 
 # TODO: optional GPU build
-pybind11_add_module(_roshambo2_cpp roshambo2/backends/cpp_src/cpp_functions.cpp)
-pybind11_add_module(_roshambo2_cuda roshambo2/backends/cuda_src/cuda_functions.cu roshambo2/backends/cuda_src/cuda_interface.cpp)
+pybind11_add_module(_roshambo2_cpp roshambo2/backends/cpp_src/cpp_functions.cpp roshambo2/backends/cpp_src/cpp_helper_functions.cpp)
+if (BUILD_WITH_CUDA)
+    pybind11_add_module(_roshambo2_cuda roshambo2/backends/cuda_src/cuda_functions.cu roshambo2/backends/cuda_src/cuda_interface.cpp)
+    target_link_libraries(_roshambo2_cuda PRIVATE OpenMP::OpenMP_CXX)
+endif (BUILD_WITH_CUDA)
 
-# Link the OpenMP library for both
 target_link_libraries(_roshambo2_cpp PRIVATE OpenMP::OpenMP_CXX)
-target_link_libraries(_roshambo2_cuda PRIVATE OpenMP::OpenMP_CXX)
-
 
 install(TARGETS _roshambo2_cpp
         LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX})
 
-
+if (BUILD_WITH_CUDA)
 install(TARGETS _roshambo2_cuda
         LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX})
+endif (BUILD_WITH_CUDA)

--- a/roshambo2/backends/cpp_src/cpp_functions.cpp
+++ b/roshambo2/backends/cpp_src/cpp_functions.cpp
@@ -324,7 +324,6 @@ void optimize_overlap_color(py::array_t<DTYPE> A, py::array_t<int> AT, py::array
                             bool optim_color, DTYPE mixing_param, DTYPE lr_q, DTYPE lr_t, int nsteps,
                             int start_mode_method, int loglevel){
 
-	std::cout << "WIBBLE WIBBLE WIBBLE" << std::endl;
     // shared arrays/pointers
     auto molAs  = A.unchecked<3>();
     auto molA_type = AT.unchecked<2>();
@@ -379,22 +378,16 @@ void optimize_overlap_color(py::array_t<DTYPE> A, py::array_t<int> AT, py::array
             // compute self overlap of A
             int NmolA_real = molA_num_atoms(k);
             int NmolA_color = NmolA -NmolA_real;
-			std::cout << "Mol A has " << NmolA_real << " atoms and " << NmolA_color << " features and "
-            << NmolA << " in total" << std::endl;
             auto self_overlap_A = volume(ptr_molA, NmolA_real, ptr_molA, NmolA_real);
             auto self_overlap_A_color = volume_color(&ptr_molA[NmolA_real*D], NmolA_color, &ptr_molA_type[NmolA_real], 
                                                     &ptr_molA[NmolA_real*D], NmolA_color, &ptr_molA_type[NmolA_real], 
                                                     ptr_rmat, ptr_pmat, N_features);
-			std::cout << "self_overlap_A: " << self_overlap_A << " color : " << self_overlap_A_color << std::endl;
 
             // parallel loop over each dataset configuration
             {
             #pragma omp parallel for
             for (long j = 0; j < molBs.shape(0); j++){
 
-#define USE_NEW 0
-#if USE_NEW == 1
-				std::cout << "NEW CODE" << std::endl;
                 // make a copy of molA and molB to transform
                 DTYPE molAT[NmolA*molAs.shape(2)];
                 std::memcpy(molAT, ptr_molA, NmolA*molAs.shape(2)*sizeof(DTYPE));
@@ -407,16 +400,14 @@ void optimize_overlap_color(py::array_t<DTYPE> A, py::array_t<int> AT, py::array
                 std::memcpy(molBT, ptr_molB, NmolB*molBs.shape(2)*sizeof(DTYPE));
                 int NmolB_real = molB_num_atoms(j);
                 int NmolB_color = NmolB -NmolB_real;
-				std::cout << "Mol B has " << NmolB_real << " atoms and " << NmolB_color << " features and "
-				<< NmolB << " in total" << std::endl;
 
 				DTYPE these_scores[20];
 				single_conformer_optimiser(ptr_molA, molAT, &ptr_molA_type[NmolA_real],
                                            NmolA, NmolA_real, NmolA_color,
-											self_overlap_A, self_overlap_A_color,
-                                            ptr_molB, molBT, &ptr_molB_type[NmolB_real],
-											NmolB, NmolB_real, NmolB_color, ptr_rmat, ptr_pmat, N_features,
-										    optim_color, mixing_param, lr_q, lr_t, nsteps, these_scores);
+										   self_overlap_A, self_overlap_A_color,
+                                           ptr_molB, molBT, &ptr_molB_type[NmolB_real],
+										   NmolB, NmolB_real, NmolB_color, ptr_rmat, ptr_pmat, N_features,
+										   optim_color, mixing_param, lr_q, lr_t, nsteps, these_scores);
 
                 // check the previous ones and keep the best
                 if (these_scores[0] > scores(k,j,0)){
@@ -442,161 +433,6 @@ void optimize_overlap_color(py::array_t<DTYPE> A, py::array_t<int> AT, py::array
                     scores(k,j,19) = start_qr[3];
 
                 } // if
-
-#else
-				std::cout << "OLD CODE" << std::endl;
-                std::array<DTYPE,4> q = {1.0,0.0,0.0,0.0}; // initial q
-                std::array<DTYPE,3> t = {0.0,0.0,0.0}; // initial t
-
-                const DTYPE * ptr_molB = molBs.data(j,0,0);
-                int NmolB = molBs.shape(1);
-                const int * ptr_molB_type = molB_type.data(j,0);
-
-                // make a copy of molA and molB to transform
-                DTYPE molBT[NmolB*molBs.shape(2)];
-                std::memcpy(molBT, ptr_molB, NmolB*molBs.shape(2)*sizeof(DTYPE));
-
-                DTYPE molAT[NmolA*molAs.shape(2)];
-                std::memcpy(molAT, ptr_molA, NmolA*molAs.shape(2)*sizeof(DTYPE));
-
-
-                DTYPE M[3][3] = {{0.0,0.0,0.0},
-                                {0.0,0.0,0.0},
-                                {0.0,0.0,0.0}};
-
-
-
-                int NmolB_real = molB_num_atoms(j);
-                int NmolB_color = NmolB -NmolB_real;
-				std::cout << "Mol B has " << NmolB_real << " atoms and " << NmolB_color << " features and "
-				<< NmolB << " in total" << std::endl;
-
-                auto self_overlap_B = volume(molBT, NmolB_real, molBT, NmolB_real);
-                auto self_overlap_B_color = volume_color(&molBT[NmolB_real*D],    NmolB_color, &ptr_molB_type[NmolB_real], 
-                                                    &molBT[NmolB_real*D],    NmolB_color, &ptr_molB_type[NmolB_real], 
-                                                    ptr_rmat, ptr_pmat, N_features);
-     			std::cout << "self_overlap_B: " << self_overlap_B << " color : " << self_overlap_B_color << std::endl;
-
-
-                std::array<DTYPE,7> cache = {0.0,0.0,0.0,0.0,0.0,0.0,0.0};
-                
-                // optimization loop
-                for(int m=0; m<nsteps; m++){
-
-
-                    // important: we must compute gradients in the reference frame of molB
-
-
-                    // 1. first we rotate molB
-
-                    quaternion_to_rotation_matrix(q, M);
-
-                    transform(M, ptr_molB, molBT, NmolB);
-
-
-                    // 2. translate molA by -t
-                    DTYPE mt[3] = {-t[0],-t[1],-t[2]};
-                    translate(mt, ptr_molA, molAT, NmolA);
-
-
-
-                    auto g = get_gradient(molAT, NmolA_real, molBT, NmolB_real);
-                    std::cout << "step " << m << "  g = ";
-                    printArray<DTYPE, 7>(g);
-                    g = g/(self_overlap_A+self_overlap_B); // normalize
-                    std::cout << "step " << m << "  ng = ";
-                    printArray<DTYPE, 7>(g);
-
-
-                    if(optim_color){
-                        auto g_c = get_gradient_color(&molAT[NmolA_real*D],    NmolA_color, &ptr_molA_type[NmolA_real], 
-                                                &molBT[NmolB_real*D],    NmolB_color, &ptr_molB_type[NmolB_real], 
-                                                ptr_rmat, ptr_pmat, N_features);
-                                std::cout << "step " << m << "  g_c = ";
-            printArray<DTYPE, 7>(g_c);
-
-                        // normalize and combine
-                        g_c = g_c/(self_overlap_A_color+self_overlap_B_color);
-                                std::cout << "step " << m << "  g_c = ";
-            printArray<DTYPE, 7>(g_c);
-                        auto g_combo = (1-mixing_param)*g + mixing_param*g_c;
-						std::cout << "step " << m << "  g_combo = ";
-						printArray<DTYPE, 7>(g_combo);
-                        adagrad_step(q, t, g_combo, cache, lr_q, lr_t);
-						std::cout << "step " << m << "  g_combo = ";
-						printArray<DTYPE, 7>(g_combo);
-                    }else{
-                        adagrad_step(q, t, g, cache, lr_q, lr_t);
-                        
-                    }
-
-                    //normalize q so that it is a unit quaternion
-                    DTYPE magq = sqrt(q[0]*q[0] + q[1]*q[1] + q[2]*q[2] * q[3]*q[3]);
-
-                    q = q/magq;
-                }
-
-                // get volume with transformed B
-                quaternion_to_rotation_matrix(q, M);
-                transform(M, ptr_molB, molBT, NmolB);
-                translate(t.data(), molBT, molBT, NmolB);
-
-                
-                auto vol = volume(ptr_molA, NmolA_real, molBT, NmolB_real);
-                // printf("v: %f\n", vol);
-
-
-                // printf("here1\n");
-                // printf("N,N: %d, %d\n", NmolA, NmolB);
-                // printf("N,N: %d, %d\n", NmolA_real, NmolB_real);
-                // printf("N,N: %d, %d\n", NmolA_color, NmolB_color);
-
-
-                auto vc = volume_color(&ptr_molA[NmolA_real*D], NmolA_color, &ptr_molA_type[NmolA_real], 
-                                    &molBT[NmolB_real*D],    NmolB_color, &ptr_molB_type[NmolB_real], 
-                                    ptr_rmat, ptr_pmat, N_features);
-                // printf("here2\n");
-                // printf("v color: %f\n", vc);
-
-
-                // compute tanimoto scores
-                auto ts = vol / (self_overlap_A + self_overlap_B - vol);
-                
-                DTYPE tc = 0.0;
-                if(optim_color){
-                    tc = vc / (self_overlap_A_color + self_overlap_B_color - vc);
-                }
-                
-                // we use the mixing param to weight the tanimotos
-                // this is the objective function we have optimized
-                auto total = (ts *(1-mixing_param) + tc*mixing_param);
-                // printf("scores: %f %f %f\n", ts, tc, total);
-
-                // check the previous ones and keep the best
-                if (total > scores(k,j,0)){
-                    scores(k,j,0) = total; // combination tanimoto of shape and color
-                    scores(k,j,1) = ts; // shape tanimoto
-                    scores(k,j,2) = tc; // color tanimoto
-                    scores(k,j,3) = vol; // volume shape
-                    scores(k,j,4) = vc; // volumes color
-                    scores(k,j,5) = self_overlap_A; // self i
-                    scores(k,j,6) = self_overlap_B; // self j
-                    scores(k,j,7) = self_overlap_A_color; // self i color
-                    scores(k,j,8) = self_overlap_B_color; // self j color
-                    scores(k,j,9)  = q[0];
-                    scores(k,j,10) = q[1];
-                    scores(k,j,11) = q[2];
-                    scores(k,j,12) = q[3];
-                    scores(k,j,13) = t[0];
-                    scores(k,j,14) = t[1];
-                    scores(k,j,15) = t[2];
-                    scores(k,j,16) = start_qr[0];
-                    scores(k,j,17) = start_qr[1];
-                    scores(k,j,18) = start_qr[2];
-                    scores(k,j,19) = start_qr[3];
-                    
-                } // if
-#endif
 
             } // for
             } // omp parallel

--- a/roshambo2/backends/cpp_src/cpp_functions.cpp
+++ b/roshambo2/backends/cpp_src/cpp_functions.cpp
@@ -306,7 +306,7 @@ std::array<DTYPE,2> self_overlap_single_color(py::array_t<DTYPE> A, py::array_t<
 /// @param AT - the padded query types
 /// @param AN - the number of heavy atoms
 /// @param B - the padded target coordinate data
-/// @param BT - the padded query types
+/// @param BT - the padded target types
 /// @param BN - the number of heavy atoms
 /// @param RMAT - interaction matrix r - linearised square matrix for looking up r for features
 /// @param PMAT - interaction matrix p - linearised square matrix for looking up p for features

--- a/roshambo2/backends/cpp_src/cpp_functions.cpp
+++ b/roshambo2/backends/cpp_src/cpp_functions.cpp
@@ -313,8 +313,8 @@ std::array<DTYPE,2> self_overlap_single_color(py::array_t<DTYPE> A, py::array_t<
 /// @param V - the output scores
 /// @param optim_color - whether to optimise on colors as well as shape
 /// @param mixing_param - how to mix the 2 tanimoto values
-/// @param lr_q - scale factor for optimising the quaternion (?)
-/// @param lr_t - scale factor for optimising the translation (?)
+/// @param lr_q - learning rate for optimising the quaternion
+/// @param lr_t - learning rate for optimising the translation
 /// @param nsteps - number of optimiser steps
 /// @param start_mode_method - 0, 1, or 2 with increasingly more start points
 /// @param loglevel - how wordy the output should be
@@ -402,10 +402,10 @@ void optimize_overlap_color(py::array_t<DTYPE> A, py::array_t<int> AT, py::array
                 int NmolB_color = NmolB -NmolB_real;
 
 				DTYPE these_scores[20];
-				single_conformer_optimiser(ptr_molA, molAT, &ptr_molA_type[NmolA_real],
+				single_conformer_optimiser(ptr_molA, molAT, ptr_molA_type,
                                            NmolA, NmolA_real, NmolA_color,
 										   self_overlap_A, self_overlap_A_color,
-                                           ptr_molB, molBT, &ptr_molB_type[NmolB_real],
+                                           ptr_molB, molBT, ptr_molB_type,
 										   NmolB, NmolB_real, NmolB_color, ptr_rmat, ptr_pmat, N_features,
 										   optim_color, mixing_param, lr_q, lr_t, nsteps, these_scores);
 
@@ -420,13 +420,13 @@ void optimize_overlap_color(py::array_t<DTYPE> A, py::array_t<int> AT, py::array
                     scores(k,j,6) = these_scores[6]; // self j
                     scores(k,j,7) = these_scores[7]; // self i color
                     scores(k,j,8) = these_scores[8]; // self j color
-                    scores(k,j,9)  = these_scores[9];
-                    scores(k,j,10) = these_scores[10];
-                    scores(k,j,11) = these_scores[11];
-                    scores(k,j,12) = these_scores[12];
-                    scores(k,j,13) = these_scores[13];
-                    scores(k,j,14) = these_scores[14];
-                    scores(k,j,15) = these_scores[15];
+                    scores(k,j,9)  = these_scores[9]; // optimised quaternion value
+                    scores(k,j,10) = these_scores[10]; // optimised quaternion value
+                    scores(k,j,11) = these_scores[11]; // optimised quaternion value
+                    scores(k,j,12) = these_scores[12]; // optimised quaternion value
+                    scores(k,j,13) = these_scores[13]; // optimised translation value
+                    scores(k,j,14) = these_scores[14]; // optimised translation value
+                    scores(k,j,15) = these_scores[15]; // optimised translation value
                     scores(k,j,16) = start_qr[0];
                     scores(k,j,17) = start_qr[1];
                     scores(k,j,18) = start_qr[2];

--- a/roshambo2/backends/cpp_src/cpp_functions.cpp
+++ b/roshambo2/backends/cpp_src/cpp_functions.cpp
@@ -43,14 +43,14 @@ enum loglevel {
 ////////////////////////////////////////////////////////////////////////////////
 /// Constants
 ////////////////////////////////////////////////////////////////////////////////
-const int D = 4;
-const DTYPE PI = 3.14159265358;
-const DTYPE KAPPA = 2.41798793102;
-const DTYPE CARBONRADII2 = 1.7*1.7;
-const DTYPE A = KAPPA/CARBONRADII2;
+constexpr int D = 4;
+constexpr DTYPE PI = 3.14159265358;
+constexpr DTYPE KAPPA = 2.41798793102;
+constexpr DTYPE CARBONRADII2 = 1.7*1.7;
+constexpr DTYPE A = KAPPA/CARBONRADII2;
 const DTYPE CONSTANT = pow(PI/(2*A), 1.5);
-const DTYPE EPSILON = 1E-9;
-const std::array<int, 3> start_mode_n = {1,4,10};
+constexpr DTYPE EPSILON = 1E-9;
+constexpr std::array<int, 3> start_mode_n = {1,4,10};
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roshambo2/backends/cpp_src/cpp_helper_functions.cpp
+++ b/roshambo2/backends/cpp_src/cpp_helper_functions.cpp
@@ -9,8 +9,8 @@
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
 //
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -42,144 +42,148 @@ const std::array<int, 3> start_mode_n = {1, 4, 10};
 /// For debug
 ////////////////////////////////////////////////////////////////////////////////
 
-template<typename T, size_t N>
-void printArray(const std::array<T, N>& arr) {
-    for (const auto& elem : arr) {
-        std::cout << elem << " ";
-    }
-    std::cout << std::endl;
+template <typename T, size_t N>
+void printArray(const std::array<T, N> &arr) {
+  for (const auto &elem : arr) {
+    std::cout << elem << " ";
+  }
+  std::cout << std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Math helper functions
 ////////////////////////////////////////////////////////////////////////////////
 
-template<typename T, size_t N>
+template <typename T, size_t N>
 std::array<T, N> operator/(const std::array<T, N> &arr, const T &scalar) {
-    std::array<T, N> result;
-    for (size_t i = 0; i < N; ++i) {
-        result[i] = arr[i] / scalar;
-    }
-    return result;
+  std::array<T, N> result;
+  for (size_t i = 0; i < N; ++i) {
+    result[i] = arr[i] / scalar;
+  }
+  return result;
 }
 
-template<typename T, size_t N>
+template <typename T, size_t N>
 std::array<T, N> operator*(const T &scalar, const std::array<T, N> &arr) {
-    std::array<T, N> result;
-    for (size_t i = 0; i < N; ++i) {
-        result[i] = scalar * arr[i];
-    }
-    return result;
+  std::array<T, N> result;
+  for (size_t i = 0; i < N; ++i) {
+    result[i] = scalar * arr[i];
+  }
+  return result;
 }
 
-template<typename T, size_t N>
-std::array<T, N> operator+(const std::array<T, N> &arr1, const std::array<T, N> &arr2) {
-    std::array<T, N> result;
-    for (size_t i = 0; i < N; ++i) {
-        result[i] = arr1[i] + arr2[i];
-    }
-    return result;
+template <typename T, size_t N>
+std::array<T, N> operator+(const std::array<T, N> &arr1,
+                           const std::array<T, N> &arr2) {
+  std::array<T, N> result;
+  for (size_t i = 0; i < N; ++i) {
+    result[i] = arr1[i] + arr2[i];
+  }
+  return result;
 }
 
-template<typename T, size_t N>
-std::array<T, N> operator*(const std::array<T, N> &arr1, const std::array<T, N> &arr2) {
-    std::array<T, N> result;
-    for (size_t i = 0; i < N; ++i) {
-        result[i] = arr1[i] * arr2[i];
-    }
-    return result;
+template <typename T, size_t N>
+std::array<T, N> operator*(const std::array<T, N> &arr1,
+                           const std::array<T, N> &arr2) {
+  std::array<T, N> result;
+  for (size_t i = 0; i < N; ++i) {
+    result[i] = arr1[i] * arr2[i];
+  }
+  return result;
 }
 
 void matvec3x3x3(DTYPE mat[][3], const DTYPE *vec, DTYPE *result) {
-    // only transforms the first 3 values in the array! The 4th value is not a
-    // coordinate so we do not transform it
+  // only transforms the first 3 values in the array! The 4th value is not a
+  // coordinate so we do not transform it
 
-    result[0] = 0.0;
-    result[1] = 0.0;
-    result[2] = 0.0;
+  result[0] = 0.0;
+  result[1] = 0.0;
+  result[2] = 0.0;
 
-    for (int i = 0; i < 3; ++i) {
-        for (int j = 0; j < 3; ++j) {
-            result[i] += mat[i][j] * vec[j];
-        }
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      result[i] += mat[i][j] * vec[j];
     }
+  }
 }
 
-std::array<DTYPE, 3> matvec3x3x3(const std::array<std::array<DTYPE, 3>, 3> &mat, const DTYPE *vec) {
-    // only transforms the first 3 values in the array! The 4th value is not a
-    // coordinate so we do not transform it
-    std::array<DTYPE, 3> result;
-    result[0] = 0.0;
-    result[1] = 0.0;
-    result[2] = 0.0;
+std::array<DTYPE, 3> matvec3x3x3(const std::array<std::array<DTYPE, 3>, 3> &mat,
+                                 const DTYPE *vec) {
+  // only transforms the first 3 values in the array! The 4th value is not a
+  // coordinate so we do not transform it
+  std::array<DTYPE, 3> result;
+  result[0] = 0.0;
+  result[1] = 0.0;
+  result[2] = 0.0;
 
-    for (int i = 0; i < 3; ++i) {
-        for (int j = 0; j < 3; ++j) {
-            result[i] += mat[i][j] * vec[j];
-        }
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      result[i] += mat[i][j] * vec[j];
     }
+  }
 
-    return result;
+  return result;
 }
 
-void matvec3x3x3(const std::array<std::array<DTYPE, 3>, 3> &mat, const DTYPE *vec, DTYPE *result) {
-    // only transforms the first 3 values in the array! The 4th value is not a
-    // coordinate so we do not transform it
+void matvec3x3x3(const std::array<std::array<DTYPE, 3>, 3> &mat,
+                 const DTYPE *vec, DTYPE *result) {
+  // only transforms the first 3 values in the array! The 4th value is not a
+  // coordinate so we do not transform it
 
-    result[0] = 0.0;
-    result[1] = 0.0;
-    result[2] = 0.0;
+  result[0] = 0.0;
+  result[1] = 0.0;
+  result[2] = 0.0;
 
-    for (int i = 0; i < 3; ++i) {
-        for (int j = 0; j < 3; ++j) {
-            result[i] += mat[i][j] * vec[j];
-        }
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      result[i] += mat[i][j] * vec[j];
     }
+  }
 }
 
 void quaternion_to_rotation_matrix(std::array<DTYPE, 4> &q, DTYPE M[3][3]) {
-    // temp variables to make more readable
-    auto w = q[0];
-    auto x = q[1];
-    auto y = q[2];
-    auto z = q[3];
+  // temp variables to make more readable
+  auto w = q[0];
+  auto x = q[1];
+  auto y = q[2];
+  auto z = q[3];
 
-    // Compute rotation matrix elements
-    M[0][0] = 1 - 2 * y * y - 2 * z * z;
-    M[0][1] = 2 * x * y - 2 * w * z;
-    M[0][2] = 2 * x * z + 2 * w * y;
-    M[1][0] = 2 * x * y + 2 * w * z;
-    M[1][1] = 1 - 2 * x * x - 2 * z * z;
-    M[1][2] = 2 * y * z - 2 * w * x;
-    M[2][0] = 2 * x * z - 2 * w * y;
-    M[2][1] = 2 * y * z + 2 * w * x;
-    M[2][2] = 1 - 2 * x * x - 2 * y * y;
+  // Compute rotation matrix elements
+  M[0][0] = 1 - 2 * y * y - 2 * z * z;
+  M[0][1] = 2 * x * y - 2 * w * z;
+  M[0][2] = 2 * x * z + 2 * w * y;
+  M[1][0] = 2 * x * y + 2 * w * z;
+  M[1][1] = 1 - 2 * x * x - 2 * z * z;
+  M[1][2] = 2 * y * z - 2 * w * x;
+  M[2][0] = 2 * x * z - 2 * w * y;
+  M[2][1] = 2 * y * z + 2 * w * x;
+  M[2][2] = 1 - 2 * x * x - 2 * y * y;
 }
 
 void transform(DTYPE mat[][3], const DTYPE *molB, DTYPE *molBT, int NmolB) {
-    // only transforms the first 3 values in the array! The 4th value is not a
-    // coordinate so we do not transform it
+  // only transforms the first 3 values in the array! The 4th value is not a
+  // coordinate so we do not transform it
 
-    for (int i = 0; i < NmolB; i++) {
-        auto x = &molB[i * D];
-        auto y = &molBT[i * D];
+  for (int i = 0; i < NmolB; i++) {
+    auto x = &molB[i * D];
+    auto y = &molBT[i * D];
 
-        matvec3x3x3(mat, x, y);
-    }
+    matvec3x3x3(mat, x, y);
+  }
 }
 
 void translate(DTYPE t[3], const DTYPE *molA, DTYPE *molAT, int NmolA) {
-    // only transforms the first 3 values in the array! The 4th value is not a
-    // coordinate so we do not transform it
+  // only transforms the first 3 values in the array! The 4th value is not a
+  // coordinate so we do not transform it
 
-    for (int i = 0; i < NmolA; i++) {
-        auto x = &molA[i * D];
-        auto y = &molAT[i * D];
+  for (int i = 0; i < NmolA; i++) {
+    auto x = &molA[i * D];
+    auto y = &molAT[i * D];
 
-        y[0] = x[0] + t[0];
-        y[1] = x[1] + t[1];
-        y[2] = x[2] + t[2];
-    }
+    y[0] = x[0] + t[0];
+    y[1] = x[1] + t[1];
+    y[2] = x[2] + t[2];
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -187,344 +191,321 @@ void translate(DTYPE t[3], const DTYPE *molA, DTYPE *molAT, int NmolA) {
 ///////////////////////////////////////////////////////////////////////////////
 
 /// @brief Calculate the atom volume overlap between mols A and B
-/// @param molA - 1D array of 4 * NmolA entries. Each block of 4 is the coords and w parameter
+/// @param molA - 1D array of 4 * NmolA entries. Each block of 4 is the coords
+/// and w parameter
 /// @param NmolA - number of atoms in A
-/// @param molB - 1D array of 4 * NmolB entries. Each block of 4 is the coords and w parameter
+/// @param molB - 1D array of 4 * NmolB entries. Each block of 4 is the coords
+/// and w parameter
 /// @param NmolA - number of atoms in B
 DTYPE volume(const DTYPE *molA, int NmolA, const DTYPE *molB, int NmolB) {
-    DTYPE V = 0.0;
+  DTYPE V = 0.0;
 
-    for (int i = 0; i < NmolA; i++) {
-        for (int j = 0; j < NmolB; j++) {
-            DTYPE dx = molA[i * D] - molB[j * D];
-            DTYPE dy = molA[i * D + 1] - molB[j * D + 1];
-            DTYPE dz = molA[i * D + 2] - molB[j * D + 2];
+  for (int i = 0; i < NmolA; i++) {
+    for (int j = 0; j < NmolB; j++) {
+      DTYPE dx = molA[i * D] - molB[j * D];
+      DTYPE dy = molA[i * D + 1] - molB[j * D + 1];
+      DTYPE dz = molA[i * D + 2] - molB[j * D + 2];
 
-            DTYPE d2 = dx * dx + dy * dy + dz * dz;
+      DTYPE d2 = dx * dx + dy * dy + dz * dz;
 
-            auto a1 = A; // left easy to change to not doing all-carbon radii
-            auto a2 = A;
+      auto a1 = A;  // left easy to change to not doing all-carbon radii
+      auto a2 = A;
 
-            DTYPE wa = molA[i * D + 3]; // wa,wb == zero means it is a padded atom
-            DTYPE wb = molB[j * D + 3];
+      DTYPE wa = molA[i * D + 3];  // wa,wb == zero means it is a padded atom
+      DTYPE wb = molB[j * D + 3];
 
-            DTYPE kij = exp(-a1 * a2 * d2 / (a1 + a2)) * wa * wb;
+      DTYPE kij = exp(-a1 * a2 * d2 / (a1 + a2)) * wa * wb;
 
-            DTYPE vij = 8 * kij * CONSTANT;
+      DTYPE vij = 8 * kij * CONSTANT;
 
-            V += vij;
-        }
+      V += vij;
     }
+  }
 
-    return V;
+  return V;
 }
 
 /// @brief Calculate the feature/color volume overlap between mols A and B.
-/// @param molA - 1D array of 4 * NmolA entries. Each block of 4 is the coords and w parameter
+/// @param molA - 1D array of 4 * NmolA entries. Each block of 4 is the coords
+/// and w parameter.
 /// @param NmolA - number of features in A
 /// @param molA_type - types of features
-/// @param molB - 1D array of 4 * NmolB entries. Each block of 4 is the coords and w parameter
+/// @param molB - 1D array of 4 * NmolB entries. Each block of 4 is the coords
+/// and w parameter
 /// @param NmolA - number of features in B
 /// @param molB_type - types of features
-/// @param rmat - interaction matrix r - linearised square matrix for looking up r for features
-/// @param pmat - interaction matrix p - linearised square matrix for looking up p for features
-/// @param N_features - the number of feature types for looking up values in rmat and pmat
+/// @param rmat - interaction matrix r - linearised square matrix for looking up
+/// r for features
+/// @param pmat - interaction matrix p - linearised square matrix for looking up
+/// p for features
+/// @param N_features - the number of feature types for looking up values in
+/// rmat and pmat
 DTYPE volume_color(const DTYPE *molA, int NmolA, const int *molA_type,
                    const DTYPE *molB, int NmolB, const int *molB_type,
                    const DTYPE *rmat, const DTYPE *pmat, int N_features) {
-    DTYPE V = 0.0;
+  DTYPE V = 0.0;
 
-    for (int i = 0; i < NmolA; i++) {
-        int ta = molA_type[i];
-        if (ta == 0) break; // padded atoms are at the end and have type==0
+  for (int i = 0; i < NmolA; i++) {
+    int ta = molA_type[i];
+    if (ta == 0) break;  // padded atoms are at the end and have type==0
+    for (int j = 0; j < NmolB; j++) {
+      int tb = molB_type[j];
+      if (tb == 0) break;
 
-        for (int j = 0; j < NmolB; j++) {
-            int tb = molB_type[j];
-            if (tb == 0) break;
+      DTYPE dx = molA[i * D] - molB[j * D];
+      DTYPE dy = molA[i * D + 1] - molB[j * D + 1];
+      DTYPE dz = molA[i * D + 2] - molB[j * D + 2];
 
-            DTYPE dx = molA[i * D] - molB[j * D];
-            DTYPE dy = molA[i * D + 1] - molB[j * D + 1];
-            DTYPE dz = molA[i * D + 2] - molB[j * D + 2];
+      DTYPE d2 = dx * dx + dy * dy + dz * dz;
 
-            DTYPE d2 = dx * dx + dy * dy + dz * dz;
+      auto a = rmat[ta * N_features + tb];
+      auto p = pmat[ta * N_features + tb];
 
-            auto a = rmat[ta * N_features + tb];
-            auto p = pmat[ta * N_features + tb];
+      DTYPE wa = molA[i * D + 3];
+      DTYPE wb = molB[j * D + 3];
 
+      DTYPE kij = exp(-a * a * d2 / (a + a)) * wa * wb;
 
-            DTYPE wa = molA[i * D + 3];
-            DTYPE wb = molB[j * D + 3];
+      double constant = pow(PI / (2 * a), 1.5);
 
-            DTYPE kij = exp(-a * a * d2 / (a + a)) * wa * wb;
+      DTYPE vij = p * p * kij * constant;
 
-            double constant = pow(PI / (2 * a), 1.5);
-
-            DTYPE vij = p * p * kij * constant;
-
-            V += vij;
-        }
+      V += vij;
     }
+  }
 
-    return V;
+  return V;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// gradient functions
 ////////////////////////////////////////////////////////////////////////////////
 
-std::array<DTYPE, 7> get_gradient(const DTYPE *molA, int NmolA, const DTYPE *molB, int NmolB) {
-    std::array<DTYPE, 7> grad = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+std::array<DTYPE, 7> get_gradient(const DTYPE *molA, int NmolA,
+                                  const DTYPE *molB, int NmolB) {
+  std::array<DTYPE, 7> grad = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
-    for (int i = 0; i < NmolA; i++) {
-        for (int j = 0; j < NmolB; j++) {
-            DTYPE dx = molA[i * D] - molB[j * D];
-            DTYPE dy = molA[i * D + 1] - molB[j * D + 1];
-            DTYPE dz = molA[i * D + 2] - molB[j * D + 2];
+  for (int i = 0; i < NmolA; i++) {
+    for (int j = 0; j < NmolB; j++) {
+      DTYPE dx = molA[i * D] - molB[j * D];
+      DTYPE dy = molA[i * D + 1] - molB[j * D + 1];
+      DTYPE dz = molA[i * D + 2] - molB[j * D + 2];
 
-            DTYPE d2 = dx * dx + dy * dy + dz * dz;
+      DTYPE d2 = dx * dx + dy * dy + dz * dz;
 
-            auto a1 = A; // left easy to change to not doing all-carbon radii
-            auto a2 = A;
+      auto a1 = A;  // left easy to change to not doing all-carbon radii
+      auto a2 = A;
 
-            DTYPE wa = molA[i * D + 3];
-            DTYPE wb = molB[j * D + 3];
+      DTYPE wa = molA[i * D + 3];
+      DTYPE wb = molB[j * D + 3];
 
-            DTYPE kij = exp(-a1 * a2 * d2 / (a1 + a2)) * wa * wb;
+      DTYPE kij = exp(-a1 * a2 * d2 / (a1 + a2)) * wa * wb;
 
-            DTYPE vij = 8 * kij * CONSTANT;
+      DTYPE vij = 8 * kij * CONSTANT;
 
-            DTYPE x = molB[j * D];
-            DTYPE y = molB[j * D + 1];
-            DTYPE z = molB[j * D + 2];
+      DTYPE x = molB[j * D];
+      DTYPE y = molB[j * D + 1];
+      DTYPE z = molB[j * D + 2];
 
-            DTYPE sks[3][3] = {
-                {0, -2 * z, 2 * y},
-                {2 * z, 0, -2 * x},
-                {-2 * y, 2 * x, 0}
-            };
+      DTYPE sks[3][3] = {
+          {0, -2 * z, 2 * y}, {2 * z, 0, -2 * x}, {-2 * y, 2 * x, 0}};
 
-            DTYPE delta[3] = {dx, dy, dz};
+      DTYPE delta[3] = {dx, dy, dz};
 
-            DTYPE mv[3] = {0.0, 0.0, 0.0};
+      DTYPE mv[3] = {0.0, 0.0, 0.0};
 
-            matvec3x3x3(sks, delta, mv);
+      matvec3x3x3(sks, delta, mv);
 
-            grad[1] += -2.0 * (a1 * a2) / (a1 + a2) * vij * mv[0];
-            grad[2] += -2.0 * (a1 * a2) / (a1 + a2) * vij * mv[1];
-            grad[3] += -2.0 * (a1 * a2) / (a1 + a2) * vij * mv[2];
+      grad[1] += -2.0 * (a1 * a2) / (a1 + a2) * vij * mv[0];
+      grad[2] += -2.0 * (a1 * a2) / (a1 + a2) * vij * mv[1];
+      grad[3] += -2.0 * (a1 * a2) / (a1 + a2) * vij * mv[2];
 
-            // x,y,z
-            grad[4] += -2.0 * (a1 * a2) / (a1 + a2) * vij * delta[0];
-            grad[5] += -2.0 * (a1 * a2) / (a1 + a2) * vij * delta[1];
-            grad[6] += -2.0 * (a1 * a2) / (a1 + a2) * vij * delta[2];
-        }
+      // x,y,z
+      grad[4] += -2.0 * (a1 * a2) / (a1 + a2) * vij * delta[0];
+      grad[5] += -2.0 * (a1 * a2) / (a1 + a2) * vij * delta[1];
+      grad[6] += -2.0 * (a1 * a2) / (a1 + a2) * vij * delta[2];
     }
+  }
 
-    return grad;
+  return grad;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Optimization functions
 ////////////////////////////////////////////////////////////////////////////////
 
-void adagrad_step(std::array<DTYPE, 4> &q, std::array<DTYPE, 3> &t, std::array<DTYPE, 7> g,
-                  std::array<DTYPE, 7> &cache, DTYPE lr_q, DTYPE lr_t) {
-    cache = cache + g * g;
+void adagrad_step(std::array<DTYPE, 4> &q, std::array<DTYPE, 3> &t,
+                  std::array<DTYPE, 7> g, std::array<DTYPE, 7> &cache,
+                  DTYPE lr_q, DTYPE lr_t) {
+  cache = cache + g * g;
 
-    q[0] -= lr_q * g[0] / (sqrt(cache[0]) + EPSILON);
-    q[1] -= lr_q * g[1] / (sqrt(cache[1]) + EPSILON);
-    q[2] -= lr_q * g[2] / (sqrt(cache[2]) + EPSILON);
-    q[3] -= lr_q * g[3] / (sqrt(cache[3]) + EPSILON);
+  q[0] -= lr_q * g[0] / (sqrt(cache[0]) + EPSILON);
+  q[1] -= lr_q * g[1] / (sqrt(cache[1]) + EPSILON);
+  q[2] -= lr_q * g[2] / (sqrt(cache[2]) + EPSILON);
+  q[3] -= lr_q * g[3] / (sqrt(cache[3]) + EPSILON);
 
-    t[0] -= lr_t * g[4] / (sqrt(cache[4]) + EPSILON);
-    t[1] -= lr_t * g[5] / (sqrt(cache[5]) + EPSILON);
-    t[2] -= lr_t * g[6] / (sqrt(cache[6]) + EPSILON);
+  t[0] -= lr_t * g[4] / (sqrt(cache[4]) + EPSILON);
+  t[1] -= lr_t * g[5] / (sqrt(cache[5]) + EPSILON);
+  t[2] -= lr_t * g[6] / (sqrt(cache[6]) + EPSILON);
 }
 
-std::array<DTYPE, 7> get_gradient_color(const DTYPE *molA, int NmolA, const int *molA_type,
-                                        const DTYPE *molB, int NmolB, const int *molB_type,
-                                        const DTYPE *rmat, const DTYPE *pmat, int N_features) {
-    std::array<DTYPE, 7> grad = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+std::array<DTYPE, 7> get_gradient_color(const DTYPE *molA, int NmolA,
+                                        const int *molA_type, const DTYPE *molB,
+                                        int NmolB, const int *molB_type,
+                                        const DTYPE *rmat, const DTYPE *pmat,
+                                        int N_features) {
+  std::array<DTYPE, 7> grad = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
-    DTYPE V = 0.0;
+  for (int i = 0; i < NmolA; i++) {
+    int ta = molA_type[i];
+    if (ta == 0) break;
 
-    for (int i = 0; i < NmolA; i++) {
-        int ta = molA_type[i];
-        if (ta == 0) break;
+    for (int j = 0; j < NmolB; j++) {
+      int tb = molB_type[j];
+      if (tb == 0) break;
 
-        for (int j = 0; j < NmolB; j++) {
-            int tb = molB_type[j];
-            if (tb == 0) break;
+      DTYPE dx = molA[i * D] - molB[j * D];
+      DTYPE dy = molA[i * D + 1] - molB[j * D + 1];
+      DTYPE dz = molA[i * D + 2] - molB[j * D + 2];
 
-            DTYPE dx = molA[i * D] - molB[j * D];
-            DTYPE dy = molA[i * D + 1] - molB[j * D + 1];
-            DTYPE dz = molA[i * D + 2] - molB[j * D + 2];
+      DTYPE d2 = dx * dx + dy * dy + dz * dz;
 
-            DTYPE d2 = dx * dx + dy * dy + dz * dz;
+      auto a = rmat[ta * N_features + tb];
+      auto p = pmat[ta * N_features + tb];
 
-            auto a = rmat[ta * N_features + tb];
-            auto p = pmat[ta * N_features + tb];
+      DTYPE wa = molA[i * D + 3];
+      DTYPE wb = molB[j * D + 3];
 
-            DTYPE wa = molA[i * D + 3];
-            DTYPE wb = molB[j * D + 3];
+      DTYPE kij = exp(-a * a * d2 / (a + a)) * wa * wb;
 
-            DTYPE kij = exp(-a * a * d2 / (a + a)) * wa * wb;
+      double constant = pow(PI / (2 * a), 1.5);
 
-            double constant = pow(PI / (2 * a), 1.5);
+      DTYPE vij = p * p * kij * constant;
 
-            DTYPE vij = p * p * kij * constant;
+      DTYPE x = molB[j * D];
+      DTYPE y = molB[j * D + 1];
+      DTYPE z = molB[j * D + 2];
 
-            DTYPE x = molB[j * D];
-            DTYPE y = molB[j * D + 1];
-            DTYPE z = molB[j * D + 2];
+      DTYPE sks[3][3] = {
+          {0, -2 * z, 2 * y}, {2 * z, 0, -2 * x}, {-2 * y, 2 * x, 0}};
 
-            DTYPE sks[3][3] = {
-                {0, -2 * z, 2 * y},
-                {2 * z, 0, -2 * x},
-                {-2 * y, 2 * x, 0}
-            };
+      DTYPE delta[3] = {dx, dy, dz};
 
-            DTYPE delta[3] = {dx, dy, dz};
+      DTYPE mv[3] = {0.0, 0.0, 0.0};
 
-            DTYPE mv[3] = {0.0, 0.0, 0.0};
+      matvec3x3x3(sks, delta, mv);
 
-            matvec3x3x3(sks, delta, mv);
+      grad[1] += -2.0 * (a * a) / (a + a) * vij * mv[0];
+      grad[2] += -2.0 * (a * a) / (a + a) * vij * mv[1];
+      grad[3] += -2.0 * (a * a) / (a + a) * vij * mv[2];
 
-            grad[1] += -2.0 * (a * a) / (a + a) * vij * mv[0];
-            grad[2] += -2.0 * (a * a) / (a + a) * vij * mv[1];
-            grad[3] += -2.0 * (a * a) / (a + a) * vij * mv[2];
-
-            // x,y,z
-            grad[4] += -2.0 * (a * a) / (a + a) * vij * delta[0];
-            grad[5] += -2.0 * (a * a) / (a + a) * vij * delta[1];
-            grad[6] += -2.0 * (a * a) / (a + a) * vij * delta[2];
-        }
+      // x,y,z
+      grad[4] += -2.0 * (a * a) / (a + a) * vij * delta[0];
+      grad[5] += -2.0 * (a * a) / (a + a) * vij * delta[1];
+      grad[6] += -2.0 * (a * a) / (a + a) * vij * delta[2];
     }
-    return grad;
+  }
+  return grad;
 }
 
-/// @brief Do the overlay for a single conformer of A against a single conformer of B
-/// @param molA - the reference molecule as 1D array of 4 * NmolA entries. Each block of 4 is the coords and w parameter
-/// @param molAT - the working copy of A
-/// @param molA_type - the features types for molecule A
-/// @param NmolA - the number of atoms and features in A
-/// @param NmolA_real - the number of atoms in A
-/// @param NmolA_color - the number of features in A
-/// @param molB - the reference molecule as 1D array of 4 * NmolB entries. Each block of 4 is the coords and w parameter
-/// @param molBT - the working copy of B
-/// @param molB_type - the features types for molecule B
-/// @param NmolB - the number of atoms and features in B
-/// @param NmolB_real - the number of atoms in B
-/// @param NmolB_color - the number of features in B
-/// @param rmat - interaction matrix r - linearised square matrix for looking up r for features
-/// @param pmat - interaction matrix p - linearised square matrix for looking up p for features
-/// @param N_features - the number of feature types for looking up values in rmat and pmat
-/// @param optim_color - whether to optimise on colors as well as shape
-/// @param mixing_param - how to mix the 2 tanimoto values
-/// @param lr_q - scale factor for optimising the quaternion (?)
-/// @param lr_t - scale factor for optimising the translation (?)
-/// @param nsteps - number of optimiser steps
-/// @params scores - the output scores and transformation to reproduce the overlay
-void single_conformer_optimiser(const DTYPE *molA, DTYPE *molAT, const int *molA_type,
-                                int NmolA, int NmolA_real, int NmolA_color,
-                                DTYPE self_overlap_A, DTYPE self_overlap_A_color,
-                                const DTYPE *molB, DTYPE *molBT, const int *molB_type,
-                                int NmolB, int NmolB_real, int NmolB_color,
-                                const DTYPE *rmat, const DTYPE *pmat, int N_features,
-                                bool optim_color, DTYPE mixing_param, DTYPE lr_q, DTYPE lr_t, int nsteps,
-                                DTYPE *scores) {
-    std::array<DTYPE, 4> q = {1.0, 0.0, 0.0, 0.0}; // initial q
-    std::array<DTYPE, 3> t = {0.0, 0.0, 0.0}; // initial t
+void single_conformer_optimiser(
+    const DTYPE *molA, DTYPE *molAT, const int *molA_type, int NmolA,
+    int NmolA_real, int NmolA_color, DTYPE self_overlap_A,
+    DTYPE self_overlap_A_color, const DTYPE *molB, DTYPE *molBT,
+    const int *molB_type, int NmolB, int NmolB_real, int NmolB_color,
+    const DTYPE *rmat, const DTYPE *pmat, int N_features, bool optim_color,
+    DTYPE mixing_param, DTYPE lr_q, DTYPE lr_t, int nsteps, DTYPE *scores) {
+  std::array<DTYPE, 4> q = {1.0, 0.0, 0.0, 0.0};  // initial q
+  std::array<DTYPE, 3> t = {0.0, 0.0, 0.0};       // initial t
 
-    DTYPE M[3][3] = {
-        {0.0, 0.0, 0.0},
-        {0.0, 0.0, 0.0},
-        {0.0, 0.0, 0.0}
-    };
+  DTYPE M[3][3] = {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
 
-    auto self_overlap_B = volume(molBT, NmolB_real, molBT, NmolB_real);
-    // For the color volume, offset the coords to start at the color features
-    auto self_overlap_B_color = volume_color(&molBT[NmolB_real*D], NmolB_color, molB_type,
-                                             &molBT[NmolB_real*D], NmolB_color, molB_type,
-                                             rmat, pmat, N_features);
-    std::array<DTYPE, 7> cache = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+  auto self_overlap_B = volume(molBT, NmolB_real, molBT, NmolB_real);
+  // For the color volume, offset the coords to start at the color features
+  auto self_overlap_B_color =
+      volume_color(&molBT[NmolB_real * D], NmolB_color, &molB_type[NmolB_real],
+                   &molBT[NmolB_real * D], NmolB_color, &molB_type[NmolB_real],
+                   rmat, pmat, N_features);
+  std::array<DTYPE, 7> cache = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
-    // optimization loop
-    for (int m = 0; m < nsteps; m++) {
-        // important: we must compute gradients in the reference frame of molB
+  // optimization loop
+  for (int m = 0; m < nsteps; m++) {
+    // important: we must compute gradients in the reference frame of molB
 
-        // 1. first we rotate molB
-        quaternion_to_rotation_matrix(q, M);
-
-        // transform molB, putting the result in molBT.
-        transform(M, molB, molBT, NmolB);
-
-        // 2. translate molA by -t, result into molAT.
-        DTYPE mt[3] = {-t[0], -t[1], -t[2]};
-        translate(mt, molA, molAT, NmolA);
-
-        auto g = get_gradient(molAT, NmolA_real, molBT, NmolB_real);
-        g = g / (self_overlap_A + self_overlap_B); // normalize
-
-        if (optim_color) {
-            // For the color gradients, offset the coords to start at the color features
-            auto g_c = get_gradient_color(&molAT[NmolA_real*D], NmolA_color, molA_type,
-                                          &molBT[NmolB_real*D], NmolB_color, molB_type,
-                                          rmat, pmat, N_features);
-            // normalize and combine
-            g_c = g_c / (self_overlap_A_color + self_overlap_B_color);
-            auto g_combo = (1 - mixing_param) * g + mixing_param * g_c;
-            adagrad_step(q, t, g_combo, cache, lr_q, lr_t);
-        } else {
-            adagrad_step(q, t, g, cache, lr_q, lr_t);
-        }
-        //normalize q so that it is a unit quaternion
-        DTYPE magq = sqrt(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] * q[3] * q[3]);
-
-        q = q / magq;
-    }
-    // get volume with transformed B
+    // 1. first we rotate molB
     quaternion_to_rotation_matrix(q, M);
+
+    // transform molB, putting the result in molBT.
     transform(M, molB, molBT, NmolB);
-    translate(t.data(), molBT, molBT, NmolB);
 
+    // 2. translate molA by -t, result into molAT.
+    DTYPE mt[3] = {-t[0], -t[1], -t[2]};
+    translate(mt, molA, molAT, NmolA);
 
-    auto vol = volume(molA, NmolA_real, molBT, NmolB_real);
+    auto g = get_gradient(molAT, NmolA_real, molBT, NmolB_real);
+    g = g / (self_overlap_A + self_overlap_B);  // normalize
 
-    auto vc = volume_color(&molA[NmolA_real*D], NmolA_color, molA_type,
-                           &molBT[NmolB_real*D], NmolB_color, molB_type,
-                           rmat, pmat, N_features);
-
-    // compute tanimoto scores
-    auto ts = vol / (self_overlap_A + self_overlap_B - vol);
-
-    DTYPE tc = 0.0;
     if (optim_color) {
-        tc = vc / (self_overlap_A_color + self_overlap_B_color - vc);
+      // For the color gradients, offset the coords and types to start at the
+      // color features.
+      auto g_c = get_gradient_color(
+          &molAT[NmolA_real * D], NmolA_color, &molA_type[NmolA_real],
+          &molBT[NmolB_real * D], NmolB_color, &molB_type[NmolB_real], rmat,
+          pmat, N_features);
+      // normalize and combine
+      g_c = g_c / (self_overlap_A_color + self_overlap_B_color);
+      auto g_combo = (1 - mixing_param) * g + mixing_param * g_c;
+      adagrad_step(q, t, g_combo, cache, lr_q, lr_t);
+    } else {
+      adagrad_step(q, t, g, cache, lr_q, lr_t);
     }
+    // normalize q so that it is a unit quaternion
+    DTYPE magq = sqrt(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] * q[3] * q[3]);
 
-    // we use the mixing param to weight the tanimotos
-    // this is the objective function we have optimized
-    auto total = (ts * (1 - mixing_param) + tc * mixing_param);
+    q = q / magq;
+  }
+  // get volume with transformed B
+  quaternion_to_rotation_matrix(q, M);
+  transform(M, molB, molBT, NmolB);
+  translate(t.data(), molBT, molBT, NmolB);
 
-    scores[0] = total; // combination tanimoto of shape and color
-    scores[1] = ts; // shape tanimoto
-    scores[2] = tc; // color tanimoto
-    scores[3] = vol; // volume shape
-    scores[4] = vc; // volumes color
-    scores[5] = self_overlap_A; // self i
-    scores[6] = self_overlap_B; // self j
-    scores[7] = self_overlap_A_color; // self i color
-    scores[8] = self_overlap_B_color; // self j color
-    scores[9] = q[0];
-    scores[10] = q[1];
-    scores[11] = q[2];
-    scores[12] = q[3];
-    scores[13] = t[0];
-    scores[14] = t[1];
-    scores[15] = t[2];
-    scores[16] = 0.0;
-    scores[17] = 0.0;
-    scores[18] = 0.0;
-    scores[19] = 0.0;
+  auto vol = volume(molA, NmolA_real, molBT, NmolB_real);
+
+  auto vc =
+      volume_color(&molA[NmolA_real * D], NmolA_color, &molA_type[NmolA_real],
+                   &molBT[NmolB_real * D], NmolB_color, &molB_type[NmolB_real],
+                   rmat, pmat, N_features);
+
+  // compute tanimoto scores
+  auto ts = vol / (self_overlap_A + self_overlap_B - vol);
+
+  DTYPE tc = 0.0;
+  if (optim_color) {
+    tc = vc / (self_overlap_A_color + self_overlap_B_color - vc);
+  }
+
+  // we use the mixing param to weight the tanimotos
+  // this is the objective function we have optimized
+  auto total = (ts * (1 - mixing_param) + tc * mixing_param);
+
+  scores[0] = total;                 // combination tanimoto of shape and color
+  scores[1] = ts;                    // shape tanimoto
+  scores[2] = tc;                    // color tanimoto
+  scores[3] = vol;                   // volume shape
+  scores[4] = vc;                    // volumes color
+  scores[5] = self_overlap_A;        // self i
+  scores[6] = self_overlap_B;        // self j
+  scores[7] = self_overlap_A_color;  // self i color
+  scores[8] = self_overlap_B_color;  // self j color
+  scores[9] = q[0];
+  scores[10] = q[1];
+  scores[11] = q[2];
+  scores[12] = q[3];
+  scores[13] = t[0];
+  scores[14] = t[1];
+  scores[15] = t[2];
+  scores[16] = 0.0;
+  scores[17] = 0.0;
+  scores[18] = 0.0;
+  scores[19] = 0.0;
 }

--- a/roshambo2/backends/cpp_src/cpp_helper_functions.cpp
+++ b/roshambo2/backends/cpp_src/cpp_helper_functions.cpp
@@ -22,8 +22,21 @@
 
 #include <array>
 #include <cmath>
+#include <iostream>
 
 using DTYPE = float;
+
+////////////////////////////////////////////////////////////////////////////////
+/// For debug
+////////////////////////////////////////////////////////////////////////////////
+
+template<typename T, size_t N>
+void printArray(const std::array<T, N>& arr) {
+    for (const auto& elem : arr) {
+        std::cout << elem << " ";
+    }
+    std::cout << std::endl;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constants
@@ -173,8 +186,22 @@ void translate(DTYPE t[3], const DTYPE *molA, DTYPE *molAT, int NmolA) {
 /// Volume functions
 ///////////////////////////////////////////////////////////////////////////////
 
+/// @brief Calculate the atom volume overlap between mols A and B
+/// @param molA - 1D array of 4 * NmolA entries. Each block of 4 is the coords and w parameter
+/// @param NmolA - number of atoms in A
+/// @param molB - 1D array of 4 * NmolB entries. Each block of 4 is the coords and w parameter
+/// @param NmolA - number of atoms in B
 DTYPE volume(const DTYPE *molA, int NmolA, const DTYPE *molB, int NmolB) {
     DTYPE V = 0.0;
+    std::cout << "volume for " << NmolA << " vs " << NmolB << std::endl;
+    for (int i = 0; i < NmolA; ++i) {
+        std::cout << i << " : " << molA[i * D] << ", " << molA[i * D + 1] << ", " << molA[i * D + 2]<< ", " << molA[i * D + 3] << std::endl;
+    }
+    std::cout << std::endl;
+    for (int i = 0; i < NmolB; ++i) {
+        std::cout << i << " : " << molB[i * D] << ", " << molB[i * D + 1] << ", " << molB[i * D + 2]<< ", " << molB[i * D + 3] << std::endl;
+    }
+    std::cout << std::endl;
 
     for (int i = 0; i < NmolA; i++) {
         for (int j = 0; j < NmolB; j++) {
@@ -201,10 +228,37 @@ DTYPE volume(const DTYPE *molA, int NmolA, const DTYPE *molB, int NmolB) {
     return V;
 }
 
+/// @brief Calculate the feature/color volume overlap between mols A and B.
+/// @param molA - 1D array of 4 * NmolA entries. Each block of 4 is the coords and w parameter
+/// @param NmolA - number of features in A
+/// @param molA_type - types of features
+/// @param molB - 1D array of 4 * NmolB entries. Each block of 4 is the coords and w parameter
+/// @param NmolA - number of features in B
+/// @param molB_type - types of features
+/// @param rmat - interaction matrix r - linearised square matrix for looking up r for features
+/// @param pmat - interaction matrix p - linearised square matrix for looking up p for features
+/// @N_features - the number of feature types for looking up values in rmat and pmat
 DTYPE volume_color(const DTYPE *molA, int NmolA, const int *molA_type,
                    const DTYPE *molB, int NmolB, const int *molB_type,
                    const DTYPE *rmat, const DTYPE *pmat, int N_features) {
     DTYPE V = 0.0;
+    std::cout << "volume_color for " << NmolA << " vs " << NmolB << std::endl;
+    for (int i = 0; i < NmolA; i++) {
+        std::cout << molA_type[i] << " ";
+    }
+    std::cout << std::endl;
+    for (int i = 0; i < NmolA; ++i) {
+        std::cout << i << " : " << molA[i * D] << ", " << molA[i * D + 1] << ", " << molA[i * D + 2]<< ", " << molA[i * D + 3] << std::endl;
+    }
+    std::cout << std::endl;
+    for (int i = 0; i < NmolB; i++) {
+        std::cout << molB_type[i] << " ";
+    }
+    std::cout << std::endl;
+    for (int i = 0; i < NmolB; ++i) {
+        std::cout << i << " : " << molB[i * D] << ", " << molB[i * D + 1] << ", " << molB[i * D + 2]<< ", " << molB[i * D + 3] << std::endl;
+    }
+    std::cout << std::endl;
 
     for (int i = 0; i < NmolA; i++) {
         int ta = molA_type[i];
@@ -391,10 +445,20 @@ void single_conformer_optimiser(const DTYPE *molA, DTYPE *molAT, const int *molA
         {0.0, 0.0, 0.0},
         {0.0, 0.0, 0.0}
     };
-    auto self_overlap_B = volume(molBT, NmolB_real, molBT, NmolB_real);
-    auto self_overlap_B_color = volume_color(molBT, NmolB_color, molB_type,
-                                             molBT, NmolB_color, molB_type,
+
+# if 0
+    auto self_overlap_AA = volume(molAT, NmolA_real, molAT, NmolA_real);
+    auto self_overlap_AA_color = volume_color(&molAT[NmolA_real*D], NmolA_color, molA_type,
+                                             &molAT[NmolA_real*D], NmolA_color, molA_type,
                                              rmat, pmat, N_features);
+    std::cout << "self_overlap_AA: " << self_overlap_AA << " color : " << self_overlap_AA_color << std::endl;
+#endif
+    auto self_overlap_B = volume(molBT, NmolB_real, molBT, NmolB_real);
+    // For the color volume, offset the coords to start at the color features
+    auto self_overlap_B_color = volume_color(&molBT[NmolB_real*D], NmolB_color, molB_type,
+                                             &molBT[NmolB_real*D], NmolB_color, molB_type,
+                                             rmat, pmat, N_features);
+    std::cout << "self_overlap_B: " << self_overlap_B << " color : " << self_overlap_B_color << std::endl;
     std::array<DTYPE, 7> cache = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
     // optimization loop
@@ -406,27 +470,40 @@ void single_conformer_optimiser(const DTYPE *molA, DTYPE *molAT, const int *molA
 
         quaternion_to_rotation_matrix(q, M);
 
+        // transform molB, putting the result in molBT.
         transform(M, molB, molBT, NmolB);
 
 
-        // 2. translate molA by -t
+        // 2. translate molA by -t, result into molAT.
         DTYPE mt[3] = {-t[0], -t[1], -t[2]};
         translate(mt, molA, molAT, NmolA);
 
 
         auto g = get_gradient(molAT, NmolA_real, molBT, NmolB_real);
+        std::cout << "step " << m << "  g = ";
+        printArray<DTYPE, 7>(g);
         g = g / (self_overlap_A + self_overlap_B); // normalize
+        std::cout << "step " << m << "  ng = ";
+        printArray<DTYPE, 7>(g);
 
 
         if (optim_color) {
-            auto g_c = get_gradient_color(&molAT[NmolA_real * D], NmolA_color, molA_type,
-                                          &molBT[NmolB_real * D], NmolB_color, molB_type,
+            // For the color volume, offset the coords to start at the color features
+            auto g_c = get_gradient_color(&molAT[NmolA_real*D], NmolA_color, molA_type,
+                                          &molBT[NmolB_real*D], NmolB_color, molB_type,
                                           rmat, pmat, N_features);
+            std::cout << "step " << m << "  g_c = ";
+            printArray<DTYPE, 7>(g_c);
 
             // normalize and combine
             g_c = g_c / (self_overlap_A_color + self_overlap_B_color);
+            std::cout << "step " << m << "  g_c = ";
+            printArray<DTYPE, 7>(g_c);
             auto g_combo = (1 - mixing_param) * g + mixing_param * g_c;
-            adagrad_step(q, t, g_combo, cache, lr_q, lr_t);
+            std::cout << "step " << m << "  g_combo = ";
+            printArray<DTYPE, 7>(g_combo);adagrad_step(q, t, g_combo, cache, lr_q, lr_t);
+            std::cout << "step " << m << "  g_combo = ";
+            printArray<DTYPE, 7>(g_combo);
         } else {
             adagrad_step(q, t, g, cache, lr_q, lr_t);
         }
@@ -443,8 +520,8 @@ void single_conformer_optimiser(const DTYPE *molA, DTYPE *molAT, const int *molA
 
     auto vol = volume(molA, NmolA_real, molBT, NmolB_real);
 
-    auto vc = volume_color(molA, NmolA_color, molA_type,
-                           molBT, NmolB_color, molB_type,
+    auto vc = volume_color(&molA[NmolA_real*D], NmolA_color, molA_type,
+                           &molBT[NmolB_real*D], NmolB_color, molB_type,
                            rmat, pmat, N_features);
 
     // compute tanimoto scores

--- a/roshambo2/backends/cpp_src/cpp_helper_functions.cpp
+++ b/roshambo2/backends/cpp_src/cpp_helper_functions.cpp
@@ -36,7 +36,6 @@ const DTYPE CARBONRADII2 = 1.7 * 1.7;
 const DTYPE A = KAPPA / CARBONRADII2;
 const DTYPE CONSTANT = pow(PI / (2 * A), 1.5);
 const DTYPE EPSILON = 1E-9;
-const std::array<int, 3> start_mode_n = {1, 4, 10};
 
 ////////////////////////////////////////////////////////////////////////////////
 /// For debug

--- a/roshambo2/backends/cpp_src/cpp_helper_functions.cpp
+++ b/roshambo2/backends/cpp_src/cpp_helper_functions.cpp
@@ -29,13 +29,13 @@ using DTYPE = float;
 ////////////////////////////////////////////////////////////////////////////////
 /// Constants
 ////////////////////////////////////////////////////////////////////////////////
-const int D = 4;
-const DTYPE PI = 3.14159265358;
-const DTYPE KAPPA = 2.41798793102;
-const DTYPE CARBONRADII2 = 1.7 * 1.7;
-const DTYPE A = KAPPA / CARBONRADII2;
+constexpr int D = 4;
+constexpr DTYPE PI = 3.14159265358;
+constexpr DTYPE KAPPA = 2.41798793102;
+constexpr DTYPE CARBONRADII2 = 1.7 * 1.7;
+constexpr DTYPE A = KAPPA / CARBONRADII2;
 const DTYPE CONSTANT = pow(PI / (2 * A), 1.5);
-const DTYPE EPSILON = 1E-9;
+constexpr DTYPE EPSILON = 1E-9;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// For debug

--- a/roshambo2/backends/cpp_src/cpp_helper_functions.cpp
+++ b/roshambo2/backends/cpp_src/cpp_helper_functions.cpp
@@ -1,0 +1,482 @@
+// MIT License
+//
+// Copyright (c) 2025 molecularinformatics
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <array>
+#include <cmath>
+
+using DTYPE = float;
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constants
+////////////////////////////////////////////////////////////////////////////////
+const int D = 4;
+const DTYPE PI = 3.14159265358;
+const DTYPE KAPPA = 2.41798793102;
+const DTYPE CARBONRADII2 = 1.7 * 1.7;
+const DTYPE A = KAPPA / CARBONRADII2;
+const DTYPE CONSTANT = pow(PI / (2 * A), 1.5);
+const DTYPE EPSILON = 1E-9;
+const std::array<int, 3> start_mode_n = {1, 4, 10};
+
+////////////////////////////////////////////////////////////////////////////////
+/// Math helper functions
+////////////////////////////////////////////////////////////////////////////////
+
+template<typename T, size_t N>
+std::array<T, N> operator/(const std::array<T, N> &arr, const T &scalar) {
+    std::array<T, N> result;
+    for (size_t i = 0; i < N; ++i) {
+        result[i] = arr[i] / scalar;
+    }
+    return result;
+}
+
+template<typename T, size_t N>
+std::array<T, N> operator*(const T &scalar, const std::array<T, N> &arr) {
+    std::array<T, N> result;
+    for (size_t i = 0; i < N; ++i) {
+        result[i] = scalar * arr[i];
+    }
+    return result;
+}
+
+template<typename T, size_t N>
+std::array<T, N> operator+(const std::array<T, N> &arr1, const std::array<T, N> &arr2) {
+    std::array<T, N> result;
+    for (size_t i = 0; i < N; ++i) {
+        result[i] = arr1[i] + arr2[i];
+    }
+    return result;
+}
+
+template<typename T, size_t N>
+std::array<T, N> operator*(const std::array<T, N> &arr1, const std::array<T, N> &arr2) {
+    std::array<T, N> result;
+    for (size_t i = 0; i < N; ++i) {
+        result[i] = arr1[i] * arr2[i];
+    }
+    return result;
+}
+
+void matvec3x3x3(DTYPE mat[][3], const DTYPE *vec, DTYPE *result) {
+    // only transforms the first 3 values in the array! The 4th value is not a
+    // coordinate so we do not transform it
+
+    result[0] = 0.0;
+    result[1] = 0.0;
+    result[2] = 0.0;
+
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            result[i] += mat[i][j] * vec[j];
+        }
+    }
+}
+
+std::array<DTYPE, 3> matvec3x3x3(const std::array<std::array<DTYPE, 3>, 3> &mat, const DTYPE *vec) {
+    // only transforms the first 3 values in the array! The 4th value is not a
+    // coordinate so we do not transform it
+    std::array<DTYPE, 3> result;
+    result[0] = 0.0;
+    result[1] = 0.0;
+    result[2] = 0.0;
+
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            result[i] += mat[i][j] * vec[j];
+        }
+    }
+
+    return result;
+}
+
+void matvec3x3x3(const std::array<std::array<DTYPE, 3>, 3> &mat, const DTYPE *vec, DTYPE *result) {
+    // only transforms the first 3 values in the array! The 4th value is not a
+    // coordinate so we do not transform it
+
+    result[0] = 0.0;
+    result[1] = 0.0;
+    result[2] = 0.0;
+
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            result[i] += mat[i][j] * vec[j];
+        }
+    }
+}
+
+void quaternion_to_rotation_matrix(std::array<DTYPE, 4> &q, DTYPE M[3][3]) {
+    // temp variables to make more readable
+    auto w = q[0];
+    auto x = q[1];
+    auto y = q[2];
+    auto z = q[3];
+
+    // Compute rotation matrix elements
+    M[0][0] = 1 - 2 * y * y - 2 * z * z;
+    M[0][1] = 2 * x * y - 2 * w * z;
+    M[0][2] = 2 * x * z + 2 * w * y;
+    M[1][0] = 2 * x * y + 2 * w * z;
+    M[1][1] = 1 - 2 * x * x - 2 * z * z;
+    M[1][2] = 2 * y * z - 2 * w * x;
+    M[2][0] = 2 * x * z - 2 * w * y;
+    M[2][1] = 2 * y * z + 2 * w * x;
+    M[2][2] = 1 - 2 * x * x - 2 * y * y;
+}
+
+void transform(DTYPE mat[][3], const DTYPE *molB, DTYPE *molBT, int NmolB) {
+    // only transforms the first 3 values in the array! The 4th value is not a
+    // coordinate so we do not transform it
+
+    for (int i = 0; i < NmolB; i++) {
+        auto x = &molB[i * D];
+        auto y = &molBT[i * D];
+
+        matvec3x3x3(mat, x, y);
+    }
+}
+
+void translate(DTYPE t[3], const DTYPE *molA, DTYPE *molAT, int NmolA) {
+    // only transforms the first 3 values in the array! The 4th value is not a
+    // coordinate so we do not transform it
+
+    for (int i = 0; i < NmolA; i++) {
+        auto x = &molA[i * D];
+        auto y = &molAT[i * D];
+
+        y[0] = x[0] + t[0];
+        y[1] = x[1] + t[1];
+        y[2] = x[2] + t[2];
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// Volume functions
+///////////////////////////////////////////////////////////////////////////////
+
+DTYPE volume(const DTYPE *molA, int NmolA, const DTYPE *molB, int NmolB) {
+    DTYPE V = 0.0;
+
+    for (int i = 0; i < NmolA; i++) {
+        for (int j = 0; j < NmolB; j++) {
+            DTYPE dx = molA[i * D] - molB[j * D];
+            DTYPE dy = molA[i * D + 1] - molB[j * D + 1];
+            DTYPE dz = molA[i * D + 2] - molB[j * D + 2];
+
+            DTYPE d2 = dx * dx + dy * dy + dz * dz;
+
+            auto a1 = A; // left easy to change to not doing all-carbon radii
+            auto a2 = A;
+
+            DTYPE wa = molA[i * D + 3]; // wa,wb == zero means it is a padded atom
+            DTYPE wb = molB[j * D + 3];
+
+            DTYPE kij = exp(-a1 * a2 * d2 / (a1 + a2)) * wa * wb;
+
+            DTYPE vij = 8 * kij * CONSTANT;
+
+            V += vij;
+        }
+    }
+
+    return V;
+}
+
+DTYPE volume_color(const DTYPE *molA, int NmolA, const int *molA_type,
+                   const DTYPE *molB, int NmolB, const int *molB_type,
+                   const DTYPE *rmat, const DTYPE *pmat, int N_features) {
+    DTYPE V = 0.0;
+
+    for (int i = 0; i < NmolA; i++) {
+        int ta = molA_type[i];
+        if (ta == 0) break; // padded atoms are at the end and have type==0
+
+        for (int j = 0; j < NmolB; j++) {
+            int tb = molB_type[j];
+            if (tb == 0) break;
+
+            DTYPE dx = molA[i * D] - molB[j * D];
+            DTYPE dy = molA[i * D + 1] - molB[j * D + 1];
+            DTYPE dz = molA[i * D + 2] - molB[j * D + 2];
+
+            DTYPE d2 = dx * dx + dy * dy + dz * dz;
+
+            auto a = rmat[ta * N_features + tb];
+            auto p = pmat[ta * N_features + tb];
+
+
+            DTYPE wa = molA[i * D + 3];
+            DTYPE wb = molB[j * D + 3];
+
+            DTYPE kij = exp(-a * a * d2 / (a + a)) * wa * wb;
+
+            double constant = pow(PI / (2 * a), 1.5);
+
+            DTYPE vij = p * p * kij * constant;
+
+            V += vij;
+        }
+    }
+
+    return V;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// gradient functions
+////////////////////////////////////////////////////////////////////////////////
+
+std::array<DTYPE, 7> get_gradient(const DTYPE *molA, int NmolA, const DTYPE *molB, int NmolB) {
+    std::array<DTYPE, 7> grad = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+
+    for (int i = 0; i < NmolA; i++) {
+        for (int j = 0; j < NmolB; j++) {
+            DTYPE dx = molA[i * D] - molB[j * D];
+            DTYPE dy = molA[i * D + 1] - molB[j * D + 1];
+            DTYPE dz = molA[i * D + 2] - molB[j * D + 2];
+
+            DTYPE d2 = dx * dx + dy * dy + dz * dz;
+
+            auto a1 = A; // left easy to change to not doing all-carbon radii
+            auto a2 = A;
+
+            DTYPE wa = molA[i * D + 3];
+            DTYPE wb = molB[j * D + 3];
+
+            DTYPE kij = exp(-a1 * a2 * d2 / (a1 + a2)) * wa * wb;
+
+            DTYPE vij = 8 * kij * CONSTANT;
+
+            DTYPE x = molB[j * D];
+            DTYPE y = molB[j * D + 1];
+            DTYPE z = molB[j * D + 2];
+
+            DTYPE sks[3][3] = {
+                {0, -2 * z, 2 * y},
+                {2 * z, 0, -2 * x},
+                {-2 * y, 2 * x, 0}
+            };
+
+            DTYPE delta[3] = {dx, dy, dz};
+
+            DTYPE mv[3] = {0.0, 0.0, 0.0};
+
+            matvec3x3x3(sks, delta, mv);
+
+            grad[1] += -2.0 * (a1 * a2) / (a1 + a2) * vij * mv[0];
+            grad[2] += -2.0 * (a1 * a2) / (a1 + a2) * vij * mv[1];
+            grad[3] += -2.0 * (a1 * a2) / (a1 + a2) * vij * mv[2];
+
+            // x,y,z
+            grad[4] += -2.0 * (a1 * a2) / (a1 + a2) * vij * delta[0];
+            grad[5] += -2.0 * (a1 * a2) / (a1 + a2) * vij * delta[1];
+            grad[6] += -2.0 * (a1 * a2) / (a1 + a2) * vij * delta[2];
+        }
+    }
+
+    return grad;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Optimization functions
+////////////////////////////////////////////////////////////////////////////////
+
+void adagrad_step(std::array<DTYPE, 4> &q, std::array<DTYPE, 3> &t, std::array<DTYPE, 7> g,
+                  std::array<DTYPE, 7> &cache, DTYPE lr_q, DTYPE lr_t) {
+    cache = cache + g * g;
+
+    q[0] -= lr_q * g[0] / (sqrt(cache[0]) + EPSILON);
+    q[1] -= lr_q * g[1] / (sqrt(cache[1]) + EPSILON);
+    q[2] -= lr_q * g[2] / (sqrt(cache[2]) + EPSILON);
+    q[3] -= lr_q * g[3] / (sqrt(cache[3]) + EPSILON);
+
+    t[0] -= lr_t * g[4] / (sqrt(cache[4]) + EPSILON);
+    t[1] -= lr_t * g[5] / (sqrt(cache[5]) + EPSILON);
+    t[2] -= lr_t * g[6] / (sqrt(cache[6]) + EPSILON);
+}
+
+std::array<DTYPE, 7> get_gradient_color(const DTYPE *molA, int NmolA, const int *molA_type,
+                                        const DTYPE *molB, int NmolB, const int *molB_type,
+                                        const DTYPE *rmat, const DTYPE *pmat, int N_features) {
+    std::array<DTYPE, 7> grad = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+
+    DTYPE V = 0.0;
+
+    for (int i = 0; i < NmolA; i++) {
+        int ta = molA_type[i];
+        if (ta == 0) break;
+
+        for (int j = 0; j < NmolB; j++) {
+            int tb = molB_type[j];
+            if (tb == 0) break;
+
+            DTYPE dx = molA[i * D] - molB[j * D];
+            DTYPE dy = molA[i * D + 1] - molB[j * D + 1];
+            DTYPE dz = molA[i * D + 2] - molB[j * D + 2];
+
+            DTYPE d2 = dx * dx + dy * dy + dz * dz;
+
+            auto a = rmat[ta * N_features + tb];
+            auto p = pmat[ta * N_features + tb];
+
+            DTYPE wa = molA[i * D + 3];
+            DTYPE wb = molB[j * D + 3];
+
+            DTYPE kij = exp(-a * a * d2 / (a + a)) * wa * wb;
+
+            double constant = pow(PI / (2 * a), 1.5);
+
+            DTYPE vij = p * p * kij * constant;
+
+            DTYPE x = molB[j * D];
+            DTYPE y = molB[j * D + 1];
+            DTYPE z = molB[j * D + 2];
+
+            DTYPE sks[3][3] = {
+                {0, -2 * z, 2 * y},
+                {2 * z, 0, -2 * x},
+                {-2 * y, 2 * x, 0}
+            };
+
+            DTYPE delta[3] = {dx, dy, dz};
+
+            DTYPE mv[3] = {0.0, 0.0, 0.0};
+
+            matvec3x3x3(sks, delta, mv);
+
+            grad[1] += -2.0 * (a * a) / (a + a) * vij * mv[0];
+            grad[2] += -2.0 * (a * a) / (a + a) * vij * mv[1];
+            grad[3] += -2.0 * (a * a) / (a + a) * vij * mv[2];
+
+            // x,y,z
+            grad[4] += -2.0 * (a * a) / (a + a) * vij * delta[0];
+            grad[5] += -2.0 * (a * a) / (a + a) * vij * delta[1];
+            grad[6] += -2.0 * (a * a) / (a + a) * vij * delta[2];
+        }
+    }
+    return grad;
+}
+
+void single_conformer_optimiser(const DTYPE *molA, DTYPE *molAT, const int *molA_type,
+                                int NmolA, int NmolA_real, int NmolA_color,
+                                DTYPE self_overlap_A, DTYPE self_overlap_A_color,
+                                const DTYPE *molB, DTYPE *molBT, const int *molB_type,
+                                int NmolB, int NmolB_real, int NmolB_color,
+                                const DTYPE *rmat, const DTYPE *pmat, int N_features,
+                                bool optim_color, DTYPE mixing_param, DTYPE lr_q, DTYPE lr_t, int nsteps,
+                                DTYPE *scores) {
+    std::array<DTYPE, 4> q = {1.0, 0.0, 0.0, 0.0}; // initial q
+    std::array<DTYPE, 3> t = {0.0, 0.0, 0.0}; // initial t
+
+    DTYPE M[3][3] = {
+        {0.0, 0.0, 0.0},
+        {0.0, 0.0, 0.0},
+        {0.0, 0.0, 0.0}
+    };
+    auto self_overlap_B = volume(molBT, NmolB_real, molBT, NmolB_real);
+    auto self_overlap_B_color = volume_color(molBT, NmolB_color, molB_type,
+                                             molBT, NmolB_color, molB_type,
+                                             rmat, pmat, N_features);
+    std::array<DTYPE, 7> cache = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+
+    // optimization loop
+    for (int m = 0; m < nsteps; m++) {
+        // important: we must compute gradients in the reference frame of molB
+
+
+        // 1. first we rotate molB
+
+        quaternion_to_rotation_matrix(q, M);
+
+        transform(M, molB, molBT, NmolB);
+
+
+        // 2. translate molA by -t
+        DTYPE mt[3] = {-t[0], -t[1], -t[2]};
+        translate(mt, molA, molAT, NmolA);
+
+
+        auto g = get_gradient(molAT, NmolA_real, molBT, NmolB_real);
+        g = g / (self_overlap_A + self_overlap_B); // normalize
+
+
+        if (optim_color) {
+            auto g_c = get_gradient_color(&molAT[NmolA_real * D], NmolA_color, molA_type,
+                                          &molBT[NmolB_real * D], NmolB_color, molB_type,
+                                          rmat, pmat, N_features);
+
+            // normalize and combine
+            g_c = g_c / (self_overlap_A_color + self_overlap_B_color);
+            auto g_combo = (1 - mixing_param) * g + mixing_param * g_c;
+            adagrad_step(q, t, g_combo, cache, lr_q, lr_t);
+        } else {
+            adagrad_step(q, t, g, cache, lr_q, lr_t);
+        }
+        //normalize q so that it is a unit quaternion
+        DTYPE magq = sqrt(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] * q[3] * q[3]);
+
+        q = q / magq;
+    }
+    // get volume with transformed B
+    quaternion_to_rotation_matrix(q, M);
+    transform(M, molB, molBT, NmolB);
+    translate(t.data(), molBT, molBT, NmolB);
+
+
+    auto vol = volume(molA, NmolA_real, molBT, NmolB_real);
+
+    auto vc = volume_color(molA, NmolA_color, molA_type,
+                           molBT, NmolB_color, molB_type,
+                           rmat, pmat, N_features);
+
+    // compute tanimoto scores
+    auto ts = vol / (self_overlap_A + self_overlap_B - vol);
+
+    DTYPE tc = 0.0;
+    if (optim_color) {
+        tc = vc / (self_overlap_A_color + self_overlap_B_color - vc);
+    }
+
+    // we use the mixing param to weight the tanimotos
+    // this is the objective function we have optimized
+    auto total = (ts * (1 - mixing_param) + tc * mixing_param);
+
+    scores[0] = total; // combination tanimoto of shape and color
+    scores[1] = ts; // shape tanimoto
+    scores[2] = tc; // color tanimoto
+    scores[3] = vol; // volume shape
+    scores[4] = vc; // volumes color
+    scores[5] = self_overlap_A; // self i
+    scores[6] = self_overlap_B; // self j
+    scores[7] = self_overlap_A_color; // self i color
+    scores[8] = self_overlap_B_color; // self j color
+    scores[9] = q[0];
+    scores[10] = q[1];
+    scores[11] = q[2];
+    scores[12] = q[3];
+    scores[13] = t[0];
+    scores[14] = t[1];
+    scores[15] = t[2];
+    scores[16] = 0.0;
+    scores[17] = 0.0;
+    scores[18] = 0.0;
+    scores[19] = 0.0;
+}

--- a/roshambo2/backends/cpp_src/cpp_helper_functions.h
+++ b/roshambo2/backends/cpp_src/cpp_helper_functions.h
@@ -17,8 +17,8 @@ using DTYPE = float;
 /// @param arr
 /// @param scalar
 /// @return
-template<typename T, size_t N>
-std::array<T, N> operator/(const std::array<T, N>& arr, const T& scalar);
+template <typename T, size_t N>
+std::array<T, N> operator/(const std::array<T, N> &arr, const T &scalar);
 
 /// @brief product of std::array by scalar
 /// @tparam T
@@ -26,8 +26,8 @@ std::array<T, N> operator/(const std::array<T, N>& arr, const T& scalar);
 /// @param arr
 /// @param scalar
 /// @return
-template<typename T, size_t N>
-std::array<T, N> operator*(const T& scalar, const std::array<T, N>& arr);
+template <typename T, size_t N>
+std::array<T, N> operator*(const T &scalar, const std::array<T, N> &arr);
 
 /// @brief addition of std::arrays
 /// @tparam T
@@ -35,8 +35,9 @@ std::array<T, N> operator*(const T& scalar, const std::array<T, N>& arr);
 /// @param arr1
 /// @param arr2
 /// @return
-template<typename T, size_t N>
-std::array<T, N> operator+(const std::array<T, N>& arr1, const std::array<T, N>& arr2);
+template <typename T, size_t N>
+std::array<T, N> operator+(const std::array<T, N> &arr1,
+                           const std::array<T, N> &arr2);
 
 /// @brief product of std::arrays
 /// @tparam T
@@ -44,45 +45,48 @@ std::array<T, N> operator+(const std::array<T, N>& arr1, const std::array<T, N>&
 /// @param arr1
 /// @param arr2
 /// @return
-template<typename T, size_t N>
-std::array<T, N> operator*(const std::array<T, N>& arr1, const std::array<T, N>& arr2);
+template <typename T, size_t N>
+std::array<T, N> operator*(const std::array<T, N> &arr1,
+                           const std::array<T, N> &arr2);
 
 /// @brief 3x3 matrix x vector
 /// @param mat matrix[3,3]
 /// @param vec 3 vector[3]
 /// @param result 3 vector[3]
-void matvec3x3x3(DTYPE mat[][3], const DTYPE * vec, DTYPE * result);
+void matvec3x3x3(DTYPE mat[][3], const DTYPE *vec, DTYPE *result);
 
 /// @brief 3x3 matrix x vector
 /// @param mat matrix[3,3]
 /// @param vec 3 vector[3]
 /// @return result 3 vector[3]
-std::array<DTYPE,3> matvec3x3x3(const std::array<std::array<DTYPE,3>,3> &mat, const DTYPE * vec);
+std::array<DTYPE, 3> matvec3x3x3(const std::array<std::array<DTYPE, 3>, 3> &mat,
+                                 const DTYPE *vec);
 
 /// @brief 3x3 matrix x vector
 /// @param mat matrix[3,3]
 /// @param vec 3 vector[3]
 /// @param result 3 vector[3]
-void matvec3x3x3(const std::array<std::array<DTYPE,3>,3> &mat, const DTYPE * vec, DTYPE * result);
+void matvec3x3x3(const std::array<std::array<DTYPE, 3>, 3> &mat,
+                 const DTYPE *vec, DTYPE *result);
 
 /// @brief convert quaternion to rotation matrix
 /// @param q quaternion[4]
 /// @param M matrix[3,3]
-void quaternion_to_rotation_matrix(std::array<DTYPE,4> &q, DTYPE M[3][3]);
+void quaternion_to_rotation_matrix(std::array<DTYPE, 4> &q, DTYPE M[3][3]);
 
 /// @brief transform molB by mat
 /// @param mat matrix[3,3]
 /// @param molB molecular coordinates[N,3]
 /// @param molBT molecular coordinates[N,3]
 /// @param NmolB N
-void transform(DTYPE mat[][3], const DTYPE * molB, DTYPE * molBT, int NmolB);
+void transform(DTYPE mat[][3], const DTYPE *molB, DTYPE *molBT, int NmolB);
 
 /// @brief translate molA to molAT by t
 /// @param t vector[3]
 /// @param molA molecular coordinates[N,3]
 /// @param molAT molecular coordinates[N,3]
 /// @param NmolA N
-void translate(DTYPE t[3], const DTYPE * molA, DTYPE * molAT, int NmolA);
+void translate(DTYPE t[3], const DTYPE *molA, DTYPE *molAT, int NmolA);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// Volume functions
@@ -94,7 +98,7 @@ void translate(DTYPE t[3], const DTYPE * molA, DTYPE * molAT, int NmolA);
 /// @param molB
 /// @param NmolB
 /// @return volume
-DTYPE volume(const DTYPE * molA, int NmolA, const DTYPE * molB, int NmolB);
+DTYPE volume(const DTYPE *molA, int NmolA, const DTYPE *molB, int NmolB);
 
 /// @brief color overlap volume of molA and molB
 /// @param molA
@@ -107,9 +111,9 @@ DTYPE volume(const DTYPE * molA, int NmolA, const DTYPE * molB, int NmolB);
 /// @param pmat
 /// @param N_features
 /// @return volume
-DTYPE volume_color(const DTYPE * molA, int NmolA, const int * molA_type,
-                   const DTYPE * molB, int NmolB, const int * molB_type,
-                   const DTYPE * rmat, const DTYPE * pmat, int N_features);
+DTYPE volume_color(const DTYPE *molA, int NmolA, const int *molA_type,
+                   const DTYPE *molB, int NmolB, const int *molB_type,
+                   const DTYPE *rmat, const DTYPE *pmat, int N_features);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// gradient functions
@@ -120,8 +124,10 @@ DTYPE volume_color(const DTYPE * molA, int NmolA, const int * molA_type,
 /// @param NmolA
 /// @param molB
 /// @param NmolB
-/// @return array[7] containing the quaternion gradients and the position gradients
-std::array<DTYPE,7> get_gradient(const DTYPE * molA, int NmolA, const DTYPE * molB, int NmolB);
+/// @return array[7] containing the quaternion gradients and the position
+/// gradients
+std::array<DTYPE, 7> get_gradient(const DTYPE *molA, int NmolA,
+                                  const DTYPE *molB, int NmolB);
 
 /// @brief compute overlap color gradients of molA and molB w.r.t molB
 /// @param molA
@@ -133,27 +139,60 @@ std::array<DTYPE,7> get_gradient(const DTYPE * molA, int NmolA, const DTYPE * mo
 /// @param rmat
 /// @param pmat
 /// @param N_features
-/// @return array[7] containing the quaternion gradients and the position gradients
-std::array<DTYPE,7> get_gradient_color(const DTYPE * molA, int NmolA, const int * molA_type,
-                                       const DTYPE * molB, int NmolB, const int * molB_type,
-                                       const DTYPE * rmat, const DTYPE * pmat, int N_features);
+/// @return array[7] containing the quaternion gradients and the position
+/// gradients
+std::array<DTYPE, 7> get_gradient_color(const DTYPE *molA, int NmolA,
+                                        const int *molA_type, const DTYPE *molB,
+                                        int NmolB, const int *molB_type,
+                                        const DTYPE *rmat, const DTYPE *pmat,
+                                        int N_features);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Optimization functions
 ////////////////////////////////////////////////////////////////////////////////
 
-
 // Adagrad optimization step
-void adagrad_step(std::array<DTYPE,4> &q, std::array<DTYPE,3> &t,  std::array<DTYPE,7> g,
-                  std::array<DTYPE,7> &cache, DTYPE lr_q, DTYPE lr_t);
+void adagrad_step(std::array<DTYPE, 4> &q, std::array<DTYPE, 3> &t,
+                  std::array<DTYPE, 7> g, std::array<DTYPE, 7> &cache,
+                  DTYPE lr_q, DTYPE lr_t);
 
-void single_conformer_optimiser(const DTYPE *molA, DTYPE *molAT, const int *molA_type,
-                                int NmolA, int NmolA_real, int NmolA_color,
-                                DTYPE self_overlap_A, DTYPE self_overlap_A_color,
-                                const DTYPE *molB, DTYPE *molBT, const int *molB_type,
-                                int NmolB, int NmolB_real, int NmolB_color,
-                                const DTYPE *rmat, const DTYPE *pmat, int N_features,
-                                bool optim_color, DTYPE mixing_param, DTYPE lr_q, DTYPE lr_t, int nsteps,
-                                DTYPE *scores);
+/// @brief Do the overlay for a single conformer of A against a single conformer
+/// of B
+/// @param molA - the query molecule as 1D array of 4 * NmolA entries. Each
+/// block of 4 is the coords and w parameter
+/// @param molAT - the working copy of A
+/// @param molA_type - the features types for molecule A
+/// @param NmolA - the number of atoms and features in A
+/// @param NmolA_real - the number of atoms in A
+/// @param NmolA_color - the number of features in A
+/// @param self_overlap_A - overlap volume of A with itself
+/// @param self_overlap_A_color - color overlap of A with itself
+/// @param molB - the target molecule as 1D array of 4 * NmolB entries. Each
+/// block of 4 is the coords and w parameter
+/// @param molBT - the working copy of B
+/// @param molB_type - the features types for molecule B
+/// @param NmolB - the number of atoms and features in B
+/// @param NmolB_real - the number of atoms in B
+/// @param NmolB_color - the number of features in B
+/// @param rmat - interaction matrix r - linearised square matrix for looking up
+/// r for features
+/// @param pmat - interaction matrix p - linearised square matrix for looking up
+/// p for features
+/// @param N_features - the number of feature types for looking up values in
+/// rmat and pmat
+/// @param optim_color - whether to optimise on colors as well as shape
+/// @param mixing_param - how to mix the 2 tanimoto values
+/// @param lr_q - scale factor for optimising the quaternion (?)
+/// @param lr_t - scale factor for optimising the translation (?)
+/// @param nsteps - number of optimiser steps
+/// @params scores - the output scores and transformation to reproduce the
+/// overlay - an array of size 20
+void single_conformer_optimiser(
+    const DTYPE *molA, DTYPE *molAT, const int *molA_type, int NmolA,
+    int NmolA_real, int NmolA_color, DTYPE self_overlap_A,
+    DTYPE self_overlap_A_color, const DTYPE *molB, DTYPE *molBT,
+    const int *molB_type, int NmolB, int NmolB_real, int NmolB_color,
+    const DTYPE *rmat, const DTYPE *pmat, int N_features, bool optim_color,
+    DTYPE mixing_param, DTYPE lr_q, DTYPE lr_t, int nsteps, DTYPE *scores);
 
-#endif //_ROSHAMBO2_CPP_HELPER_FUNCTIONS_H
+#endif  //_ROSHAMBO2_CPP_HELPER_FUNCTIONS_H

--- a/roshambo2/backends/cpp_src/cpp_helper_functions.h
+++ b/roshambo2/backends/cpp_src/cpp_helper_functions.h
@@ -157,7 +157,8 @@ void adagrad_step(std::array<DTYPE, 4> &q, std::array<DTYPE, 3> &t,
                   DTYPE lr_q, DTYPE lr_t);
 
 /// @brief Do the overlay for a single conformer of A against a single conformer
-/// of B
+/// of B.  The output in scores is the rotation and translation that moves B
+/// to optimise its score with A.
 /// @param molA - the query molecule as 1D array of 4 * NmolA entries. Each
 /// block of 4 is the coords and w parameter
 /// @param molAT - the working copy of A
@@ -169,7 +170,8 @@ void adagrad_step(std::array<DTYPE, 4> &q, std::array<DTYPE, 3> &t,
 /// @param self_overlap_A_color - color overlap of A with itself
 /// @param molB - the target molecule as 1D array of 4 * NmolB entries. Each
 /// block of 4 is the coords and w parameter
-/// @param molBT - the working copy of B
+/// @param molBT - the working copy of B - the final overlaid coordinates will
+/// be left here
 /// @param molB_type - the features types for molecule B
 /// @param NmolB - the number of atoms and features in B
 /// @param NmolB_real - the number of atoms in B
@@ -185,8 +187,20 @@ void adagrad_step(std::array<DTYPE, 4> &q, std::array<DTYPE, 3> &t,
 /// @param lr_q - scale factor for optimising the quaternion (?)
 /// @param lr_t - scale factor for optimising the translation (?)
 /// @param nsteps - number of optimiser steps
-/// @params scores - the output scores and transformation to reproduce the
-/// overlay - an array of size 20
+/// @return scores - the output scores and transformation to reproduce the
+/// overlay - an array of size 20. Only the first 16 are used here. They are:
+/// 0 - the combo score
+/// 1 - the shape tanimoto
+/// 2 - the color tanimoto
+/// 3 - the overlap volume
+/// 4 - the color overlap volume
+/// 5 - the volume of A
+/// 6 - the volume of B
+/// 7 - the color volume of A
+/// 8 - the color volume of B
+/// 9-12 - the quaternion to rotate B onto A. Applied first.
+/// 13-15 - the translation to move B onto A. Applied second.
+/// 16-19 - returned as zeros.
 void single_conformer_optimiser(
     const DTYPE *molA, DTYPE *molAT, const int *molA_type, int NmolA,
     int NmolA_real, int NmolA_color, DTYPE self_overlap_A,

--- a/roshambo2/backends/cpp_src/cpp_helper_functions.h
+++ b/roshambo2/backends/cpp_src/cpp_helper_functions.h
@@ -1,0 +1,159 @@
+//
+// Created by dave on 04/12/2025.
+//
+
+#ifndef _ROSHAMBO2_CPP_HELPER_FUNCTIONS_H
+#define _ROSHAMBO2_CPP_HELPER_FUNCTIONS_H
+
+using DTYPE = float;
+
+////////////////////////////////////////////////////////////////////////////////
+/// Math helper functions
+////////////////////////////////////////////////////////////////////////////////
+
+/// @brief division of std::array by scalar
+/// @tparam T
+/// @tparam N
+/// @param arr
+/// @param scalar
+/// @return
+template<typename T, size_t N>
+std::array<T, N> operator/(const std::array<T, N>& arr, const T& scalar);
+
+/// @brief product of std::array by scalar
+/// @tparam T
+/// @tparam N
+/// @param arr
+/// @param scalar
+/// @return
+template<typename T, size_t N>
+std::array<T, N> operator*(const T& scalar, const std::array<T, N>& arr);
+
+/// @brief addition of std::arrays
+/// @tparam T
+/// @tparam N
+/// @param arr1
+/// @param arr2
+/// @return
+template<typename T, size_t N>
+std::array<T, N> operator+(const std::array<T, N>& arr1, const std::array<T, N>& arr2);
+
+/// @brief product of std::arrays
+/// @tparam T
+/// @tparam N
+/// @param arr1
+/// @param arr2
+/// @return
+template<typename T, size_t N>
+std::array<T, N> operator*(const std::array<T, N>& arr1, const std::array<T, N>& arr2);
+
+/// @brief 3x3 matrix x vector
+/// @param mat matrix[3,3]
+/// @param vec 3 vector[3]
+/// @param result 3 vector[3]
+void matvec3x3x3(DTYPE mat[][3], const DTYPE * vec, DTYPE * result);
+
+/// @brief 3x3 matrix x vector
+/// @param mat matrix[3,3]
+/// @param vec 3 vector[3]
+/// @return result 3 vector[3]
+std::array<DTYPE,3> matvec3x3x3(const std::array<std::array<DTYPE,3>,3> &mat, const DTYPE * vec);
+
+/// @brief 3x3 matrix x vector
+/// @param mat matrix[3,3]
+/// @param vec 3 vector[3]
+/// @param result 3 vector[3]
+void matvec3x3x3(const std::array<std::array<DTYPE,3>,3> &mat, const DTYPE * vec, DTYPE * result);
+
+/// @brief convert quaternion to rotation matrix
+/// @param q quaternion[4]
+/// @param M matrix[3,3]
+void quaternion_to_rotation_matrix(std::array<DTYPE,4> &q, DTYPE M[3][3]);
+
+/// @brief transform molB by mat
+/// @param mat matrix[3,3]
+/// @param molB molecular coordinates[N,3]
+/// @param molBT molecular coordinates[N,3]
+/// @param NmolB N
+void transform(DTYPE mat[][3], const DTYPE * molB, DTYPE * molBT, int NmolB);
+
+/// @brief translate molA to molAT by t
+/// @param t vector[3]
+/// @param molA molecular coordinates[N,3]
+/// @param molAT molecular coordinates[N,3]
+/// @param NmolA N
+void translate(DTYPE t[3], const DTYPE * molA, DTYPE * molAT, int NmolA);
+
+///////////////////////////////////////////////////////////////////////////////
+/// Volume functions
+///////////////////////////////////////////////////////////////////////////////
+
+/// @brief shape overlap volume of molA and molB
+/// @param molA
+/// @param NmolA
+/// @param molB
+/// @param NmolB
+/// @return volume
+DTYPE volume(const DTYPE * molA, int NmolA, const DTYPE * molB, int NmolB);
+
+/// @brief color overlap volume of molA and molB
+/// @param molA
+/// @param NmolA
+/// @param molA_type
+/// @param molB
+/// @param NmolB
+/// @param molB_type
+/// @param rmat
+/// @param pmat
+/// @param N_features
+/// @return volume
+DTYPE volume_color(const DTYPE * molA, int NmolA, const int * molA_type,
+                   const DTYPE * molB, int NmolB, const int * molB_type,
+                   const DTYPE * rmat, const DTYPE * pmat, int N_features);
+
+////////////////////////////////////////////////////////////////////////////////
+/// gradient functions
+////////////////////////////////////////////////////////////////////////////////
+
+/// @brief compute overlap gradients of molA and molB w.r.t molB
+/// @param molA
+/// @param NmolA
+/// @param molB
+/// @param NmolB
+/// @return array[7] containing the quaternion gradients and the position gradients
+std::array<DTYPE,7> get_gradient(const DTYPE * molA, int NmolA, const DTYPE * molB, int NmolB);
+
+/// @brief compute overlap color gradients of molA and molB w.r.t molB
+/// @param molA
+/// @param NmolA
+/// @param molA_type
+/// @param molB
+/// @param NmolB
+/// @param molB_type
+/// @param rmat
+/// @param pmat
+/// @param N_features
+/// @return array[7] containing the quaternion gradients and the position gradients
+std::array<DTYPE,7> get_gradient_color(const DTYPE * molA, int NmolA, const int * molA_type,
+                                       const DTYPE * molB, int NmolB, const int * molB_type,
+                                       const DTYPE * rmat, const DTYPE * pmat, int N_features);
+
+////////////////////////////////////////////////////////////////////////////////
+/// Optimization functions
+////////////////////////////////////////////////////////////////////////////////
+
+
+// Adagrad optimization step
+void adagrad_step(std::array<DTYPE,4> &q, std::array<DTYPE,3> &t,  std::array<DTYPE,7> g,
+                  std::array<DTYPE,7> &cache, DTYPE lr_q, DTYPE lr_t);
+
+void single_conformer_optimiser(const DTYPE *molA, DTYPE *molAT, const int *molA_type,
+                                int NmolA, int NmolA_real, int NmolA_color,
+                                DTYPE self_overlap_A, DTYPE self_overlap_A_color,
+                                const DTYPE *molB, DTYPE *molBT, const int *molB_type,
+                                int NmolB, int NmolB_real, int NmolB_color,
+                                const DTYPE *rmat, const DTYPE *pmat, int N_features,
+                                bool optim_color, DTYPE mixing_param, DTYPE lr_q, DTYPE lr_t, int nsteps,
+                                DTYPE *scores);
+
+#endif //_ROSHAMBO2_CPP_HELPER_FUNCTIONS_H


### PR DESCRIPTION
This splits the C++ code for doing a single conformer overlay out into a separate compilation unit so that it is decoupled from the pybind11 interface.  The reason is so that it can then be called from a C++ program directly.  The intention is to use it for shape-based overlay in the RDKit, especially the shape-based Synthon Space searching I am working on.

I have tried to make it as minimally invasive as possible, to ease the review.  I have had to make the compilation of the CUDA part optional as I don't have a GPU on my machine, but haven't followed that through to the Python installer.

I have done some testing, but found it difficult due to not having a GPU.  